### PR TITLE
Fix data refresh when returning to tab

### DIFF
--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -1,11 +1,14 @@
 <script>
   import { onMount } from 'svelte';
+  import { afterNavigate } from '$app/navigation';
   import { supabase } from '$lib/supabaseClient';
 
   let leaderboard = [];
   let message = '';
+  let cleanupRehydration;
+  let cleanupNavigation;
 
-  onMount(async () => {
+  async function loadLeaderboard() {
     const { data, error } = await supabase
       .from('point_submissions')
       .select(`
@@ -19,6 +22,7 @@
     if (error) {
       console.error('Error loading leaderboard:', error);
       message = 'Failed to load leaderboard.';
+      leaderboard = [];
       return;
     }
 
@@ -39,6 +43,30 @@
     leaderboard = Array.from(totals.values())
       .sort((a, b) => b.points - a.points)
       .slice(0, 10);
+  }
+
+  function setupRehydration() {
+    const handler = () => loadLeaderboard();
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') handler();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('focus', handler);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('focus', handler);
+    };
+  }
+
+  cleanupNavigation = afterNavigate(loadLeaderboard);
+
+  onMount(() => {
+    loadLeaderboard();
+    cleanupRehydration = setupRehydration();
+    return () => {
+      if (cleanupRehydration) cleanupRehydration();
+      if (cleanupNavigation) cleanupNavigation();
+    };
   });
 </script>
 

--- a/src/routes/officers/view-all/+page.svelte
+++ b/src/routes/officers/view-all/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import { supabase } from '$lib/supabaseClient';
   import { onMount } from 'svelte';
+  import { afterNavigate } from '$app/navigation';
 
   let submissions = [];
   let filtered = [];
@@ -12,11 +13,36 @@
     endDate: ''
   };
   let isMobile = false;
+  let cleanupRehydration;
+  let cleanupNavigation;
+
+  function setupRehydration() {
+    const handler = () => loadSubmissions();
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') handler();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('focus', handler);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('focus', handler);
+    };
+  }
+
+  cleanupNavigation = afterNavigate(loadSubmissions);
 
   onMount(() => {
     isMobile = window.innerWidth < 768;
-    window.addEventListener('resize', () => isMobile = window.innerWidth < 768);
+    const resize = () => (isMobile = window.innerWidth < 768);
+    window.addEventListener('resize', resize);
     loadSubmissions();
+    cleanupRehydration = setupRehydration();
+
+    return () => {
+      if (cleanupRehydration) cleanupRehydration();
+      if (cleanupNavigation) cleanupNavigation();
+      window.removeEventListener('resize', resize);
+    };
   });
 
   async function loadSubmissions() {


### PR DESCRIPTION
## Summary
- refresh leaderboard data when tab is focused or when navigating
- refresh approval page data when tab is focused or when navigating
- refresh officer view-all page when tab is focused or when navigating

## Testing
- `npm run check` *(fails: `svelte-kit: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c86f22f908331ae1464c30a4a8365