### PR TITLE
Fix data refresh when returning to tab

### DIFF
--- a/src/routes/my-submissions/+page.svelte
+++ b/src/routes/my-submissions/+page.svelte
@@ -13,6 +13,9 @@
   let sortColumn = "event_date";
   let sortDirection = "desc";
 
+  let lastLoaded = 0;
+  const CACHE_MS = 10000;
+
   // -------------------------------
   // 1. Reactive derivation of "submissions" from "allSubmissions" + "showAll"
   // -------------------------------
@@ -36,7 +39,12 @@
   // -------------------------------
   // 2. loadAllSubmissions(): fetches full array from Supabase
   // -------------------------------
-  async function loadAllSubmissions() {
+  async function loadAllSubmissions(force = false) {
+    if (!force && Date.now() - lastLoaded < CACHE_MS) {
+      console.log("[submissions] loadAllSubmissions() skipped (cached)");
+      return;
+    }
+    lastLoaded = Date.now();
     console.log("[submissions] loadAllSubmissions(): showAll =", showAll);
 
     const {
@@ -96,7 +104,7 @@
     console.log(
       `[submissions] sortTable: sortColumn = ${sortColumn}, sortDirection = ${sortDirection}`,
     );
-    loadAllSubmissions();
+    loadAllSubmissions(true);
   }
 
   function formatStatus(sub) {
@@ -134,7 +142,7 @@
 
   const cleanupNavigation = afterNavigate(() => {
     console.log("[submissions] afterNavigate → reload allSubmissions");
-    loadAllSubmissions();
+    loadAllSubmissions(true);
   });
 
 
@@ -144,7 +152,7 @@
     console.log(
       "[submissions] onMount → initial loadAllSubmissions + setupRehydration",
     );
-    loadAllSubmissions();
+    loadAllSubmissions(true);
     cleanupRehydration = setupRehydration();
 
     // Mobile check setup

--- a/src/routes/officers/approvals/+page.svelte
+++ b/src/routes/officers/approvals/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import { supabase } from "$lib/supabaseClient";
   import { onMount } from "svelte";
+  import { afterNavigate } from "$app/navigation";
   import toast from "svelte-french-toast";
 
   let submissions = [];
@@ -10,13 +11,43 @@
   let showRejectModal = false;
   let rejectionReason = "";
   let isMobile = false;
+  let cleanupRehydration;
+  let cleanupNavigation;
+  let lastLoaded = 0;
+  const CACHE_MS = 10000;
+
+  function setupRehydration() {
+    const handler = () => loadSubmissions();
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') handler();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('focus', handler);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('focus', handler);
+    };
+  }
+
+  cleanupNavigation = afterNavigate(() => loadSubmissions(true));
 
   onMount(() => {
-    loadSubmissions();
+    loadSubmissions(true);
+    cleanupRehydration = setupRehydration();
     isMobile = window.innerWidth < 768;
+    const resize = () => (isMobile = window.innerWidth < 768);
+    window.addEventListener('resize', resize);
+
+    return () => {
+      if (cleanupRehydration) cleanupRehydration();
+      if (cleanupNavigation) cleanupNavigation();
+      window.removeEventListener('resize', resize);
+    };
   });
 
-  async function loadSubmissions() {
+  async function loadSubmissions(force = false) {
+    if (!force && Date.now() - lastLoaded < CACHE_MS) return;
+    lastLoaded = Date.now();
     const { data, error } = await supabase
       .from("point_submissions")
       .select(`

--- a/src/routes/officers/view-all/+page.svelte
+++ b/src/routes/officers/view-all/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import { supabase } from '$lib/supabaseClient';
   import { onMount } from 'svelte';
+  import { afterNavigate } from '$app/navigation';
 
   let submissions = [];
   let filtered = [];
@@ -12,14 +13,43 @@
     endDate: ''
   };
   let isMobile = false;
+  let cleanupRehydration;
+  let cleanupNavigation;
+  let lastLoaded = 0;
+  const CACHE_MS = 10000;
+
+  function setupRehydration() {
+    const handler = () => loadSubmissions();
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') handler();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('focus', handler);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('focus', handler);
+    };
+  }
+
+  cleanupNavigation = afterNavigate(() => loadSubmissions(true));
 
   onMount(() => {
     isMobile = window.innerWidth < 768;
-    window.addEventListener('resize', () => isMobile = window.innerWidth < 768);
-    loadSubmissions();
+    const resize = () => (isMobile = window.innerWidth < 768);
+    window.addEventListener('resize', resize);
+    loadSubmissions(true);
+    cleanupRehydration = setupRehydration();
+
+    return () => {
+      if (cleanupRehydration) cleanupRehydration();
+      if (cleanupNavigation) cleanupNavigation();
+      window.removeEventListener('resize', resize);
+    };
   });
 
-  async function loadSubmissions() {
+  async function loadSubmissions(force = false) {
+    if (!force && Date.now() - lastLoaded < CACHE_MS) return;
+    lastLoaded = Date.now();
     const { data, error } = await supabase
       .from('point_submissions')
       .select(`id, category, description, points, event_date, approved, rejection_reason, members(name)`)  // assuming FK is setup


### PR DESCRIPTION
## Summary
- refresh leaderboard, approval, and view-all pages on tab focus
- throttle refresh calls with a small cache window
- keep My Submissions data fresh on tab focus

## Testing
- `npm run check` *(fails: `svelte-kit: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c86f22f908331ae1464c30a4a8365