### PR TITLE
Fix datetime validation to allow same-day entries and judging

### DIFF
--- a/src/routes/officers/manage-competitions/create/+page.svelte
+++ b/src/routes/officers/manage-competitions/create/+page.svelte
@@ -86,11 +86,11 @@
     if (!judgingDate) {
       errors.judgingDate = 'Judging date is required';
     } else {
-      const judging = new Date(judgingDate);
-      const deadline = new Date(entryDeadline);
+      const judging = new Date(`${judgingDate}T${judgingDateTime}:00`);
+      const deadline = new Date(`${entryDeadline}T${entryDeadlineTime}:00`);
       
       if (judging <= deadline) {
-        errors.judgingDate = 'Judging date must be after entry deadline';
+        errors.judgingDate = 'Judging date and time must be after entry deadline';
       }
     }
     

--- a/src/routes/officers/manage-competitions/edit/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/edit/[id]/+page.svelte
@@ -125,11 +125,11 @@
     if (!judgingDate) {
       errors.judgingDate = 'Judging date is required';
     } else {
-      const judging = new Date(judgingDate);
-      const deadline = new Date(entryDeadline);
+      const judging = new Date(`${judgingDate}T${judgingDateTime}:00`);
+      const deadline = new Date(`${entryDeadline}T${entryDeadlineTime}:00`);
       
       if (judging <= deadline) {
-        errors.judgingDate = 'Judging date must be after entry deadline';
+        errors.judgingDate = 'Judging date and time must be after entry deadline';
       }
     }
     


### PR DESCRIPTION
Updated validation logic to compare full datetime (date + time) instead of just dates, allowing competitions with entry deadline and judging on the same day at different times (e.g., entries close 1:00 PM, judging at 2:00 PM).

🤖 Generated with [Claude Code](https://claude.ai/code)