### PR TITLE
Hide beer names from non-Competition Directors across all judging int…

### DIFF
--- a/src/routes/judge/competition/[id]/+page.svelte
+++ b/src/routes/judge/competition/[id]/+page.svelte
@@ -29,6 +29,17 @@
   let showScoreBreakdown = false;
   let autoSaveTimeout = null;
 
+  // Check if current user is Comp Director for displaying beer names
+  $: isCompDirector = $userProfile?.role === 'competition_director';
+
+  // Helper function to get beer name display
+  function getBeerNameDisplay(beerName) {
+    if (isCompDirector) {
+      return beerName || 'No name provided';
+    }
+    return 'Hidden'; // Hidden for non-Comp Directors
+  }
+
   // Score maximums for validation
   const scoreMaximums = {
     aroma_score: 12,
@@ -788,7 +799,7 @@
           <div class="entry-details">
             <div class="detail-item">
               <span class="detail-label">Beer Name</span>
-              <span class="detail-value">{$currentEntry.beer_name || 'No name provided'}</span>
+              <span class="detail-value">{getBeerNameDisplay($currentEntry.beer_name)}</span>
             </div>
             <div class="detail-item">
               <span class="detail-label">Category</span>

--- a/src/routes/judge/competition/[id]/scoresheet/+page.svelte
+++ b/src/routes/judge/competition/[id]/scoresheet/+page.svelte
@@ -18,6 +18,17 @@
   let autoSaveTimeout = null;
   let currentEntryId = null; // Track current entry to prevent unnecessary reloading
 
+  // Check if current user is Comp Director for displaying beer names
+  $: isCompDirector = $userProfile?.role === 'competition_director';
+
+  // Helper function to get beer name display
+  function getBeerNameDisplay(beerName) {
+    if (isCompDirector) {
+      return beerName || 'No name provided';
+    }
+    return 'Hidden'; // Hidden for non-Comp Directors
+  }
+
   // BJCP Score Sheet Data Structure
   let scoresheetData = {
     // Scoring fields
@@ -681,7 +692,7 @@
         </div>
         <div class="info-group">
           <span class="info-label">Beer Name</span>
-          <span class="info-value">{$currentEntry.beer_name || 'No name provided'}</span>
+          <span class="info-value">{getBeerNameDisplay($currentEntry.beer_name)}</span>
         </div>
         <div class="info-group">
           <span class="info-label">Subcategory</span>

--- a/src/routes/officers/manage-competitions/judging-dashboard/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/judging-dashboard/[id]/+page.svelte
@@ -50,6 +50,14 @@
     return isCompDirector ? '' : 'brewer-name-hidden';
   }
 
+  // Helper function to get beer name display
+  function getBeerNameDisplay(beerName) {
+    if (isCompDirector) {
+      return beerName || 'Unknown Beer';
+    }
+    return 'Hidden'; // Hidden for non-Comp Directors
+  }
+
   onMount(() => {
     loadDashboardData();
   });
@@ -1245,7 +1253,7 @@
                   <td>
                     <div>
                       <div style="font-weight: 600; color: #ff3e00;">#{entry.entry_number}</div>
-                      <div style="font-size: 0.875rem;">{entry.beer_name || 'No name'}</div>
+                      <div class="{getBrewerNameClass()}" style="font-size: 0.875rem;">{getBeerNameDisplay(entry.beer_name)}</div>
                     </div>
                   </td>
                   <td><span class="{getBrewerNameClass()}">{getBrewerNameDisplay(entry.members?.name)}</span></td>
@@ -1288,7 +1296,7 @@
                 <div class="mobile-card-header">
                   <div>
                     <h3 class="mobile-card-title">#{entry.entry_number}</h3>
-                    <div class="mobile-card-subtitle">{entry.beer_name || 'No name'}</div>
+                    <div class="mobile-card-subtitle {getBrewerNameClass()}">{getBeerNameDisplay(entry.beer_name)}</div>
                   </div>
                   <div class="mobile-card-badge" style="background: {scores.count === judges.length ? '#dcfce7' : scores.count > 0 ? '#fef3c7' : '#fee2e2'}; color: {scores.count === judges.length ? '#059669' : scores.count > 0 ? '#f59e0b' : '#dc2626'};">
                     {scores.count === judges.length ? 'Complete' : scores.count > 0 ? 'Partial' : 'Pending'}
@@ -1400,7 +1408,7 @@
                             <td>
                               <div>
                                 <div style="font-weight: 600; color: #ff3e00;">#{entry.entry_number}</div>
-                                <div style="font-size: 0.875rem;">{entry.beer_name || 'No name'}</div>
+                                <div class="{getBrewerNameClass()}" style="font-size: 0.875rem;">{getBeerNameDisplay(entry.beer_name)}</div>
                               </div>
                             </td>
                             <td>
@@ -1446,7 +1454,7 @@
                             <td>
                               <div>
                                 <div style="font-weight: 600; color: #ff3e00;">#{ranking.entry?.entry_number}</div>
-                                <div style="font-size: 0.875rem;">{ranking.entry?.beer_name || 'No name'}</div>
+                                <div class="{getBrewerNameClass()}" style="font-size: 0.875rem;">{getBeerNameDisplay(ranking.entry?.beer_name)}</div>
                               </div>
                             </td>
                             <td>
@@ -1509,7 +1517,7 @@
                             <td>
                               <div>
                                 <div style="font-weight: 600; color: #ff3e00;">#{entry.entry_number}</div>
-                                <div style="font-size: 0.875rem;">{entry.beer_name || 'No name'}</div>
+                                <div class="{getBrewerNameClass()}" style="font-size: 0.875rem;">{getBeerNameDisplay(entry.beer_name)}</div>
                               </div>
                             </td>
                             <td>
@@ -1555,7 +1563,7 @@
                             <td>
                               <div>
                                 <div style="font-weight: 600; color: #ff3e00;">#{ranking.entry?.entry_number}</div>
-                                <div style="font-size: 0.875rem;">{ranking.entry?.beer_name || 'No name'}</div>
+                                <div class="{getBrewerNameClass()}" style="font-size: 0.875rem;">{getBeerNameDisplay(ranking.entry?.beer_name)}</div>
                               </div>
                             </td>
                             <td>
@@ -1617,7 +1625,7 @@
                             </div>
                             <div class="mobile-ranking-entry">
                               <div class="mobile-ranking-entry-number">#{entry.entry_number}</div>
-                              <div class="mobile-ranking-beer-name">{entry.beer_name || 'No name'}</div>
+                              <div class="mobile-ranking-beer-name {getBrewerNameClass()}">{getBeerNameDisplay(entry.beer_name)}</div>
                               <div style="font-size: 0.8rem; color: #666; margin-top: 0.25rem;">
                                 {entry.summary.judgeCount} judge{entry.summary.judgeCount === 1 ? '' : 's'} • {placement}
                               </div>
@@ -1636,7 +1644,7 @@
                             </div>
                             <div class="mobile-ranking-entry">
                               <div class="mobile-ranking-entry-number">#{ranking.entry?.entry_number}</div>
-                              <div class="mobile-ranking-beer-name">{ranking.entry?.beer_name || 'No name'}</div>
+                              <div class="mobile-ranking-beer-name {getBrewerNameClass()}">{getBeerNameDisplay(ranking.entry?.beer_name)}</div>
                               <div style="font-size: 0.8rem; color: #666; margin-top: 0.25rem;">
                                 {ranking.judge?.name}{#if ranking.ranking_notes} • {ranking.ranking_notes}{/if}
                               </div>
@@ -1688,7 +1696,7 @@
                             </div>
                             <div class="mobile-ranking-entry">
                               <div class="mobile-ranking-entry-number">#{entry.entry_number}</div>
-                              <div class="mobile-ranking-beer-name">{entry.beer_name || 'No name'}</div>
+                              <div class="mobile-ranking-beer-name {getBrewerNameClass()}">{getBeerNameDisplay(entry.beer_name)}</div>
                               <div style="font-size: 0.8rem; color: #666; margin-top: 0.25rem;">
                                 {entry.summary.judgeCount} judge{entry.summary.judgeCount === 1 ? '' : 's'} • {placement}
                               </div>
@@ -1707,7 +1715,7 @@
                             </div>
                             <div class="mobile-ranking-entry">
                               <div class="mobile-ranking-entry-number">#{ranking.entry?.entry_number}</div>
-                              <div class="mobile-ranking-beer-name">{ranking.entry?.beer_name || 'No name'}</div>
+                              <div class="mobile-ranking-beer-name {getBrewerNameClass()}">{getBeerNameDisplay(ranking.entry?.beer_name)}</div>
                               <div style="font-size: 0.8rem; color: #666; margin-top: 0.25rem;">
                                 {ranking.judge?.name}{#if ranking.ranking_notes} • {ranking.ranking_notes}{/if}
                               </div>

--- a/src/routes/officers/manage-competitions/results/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/results/[id]/+page.svelte
@@ -52,6 +52,14 @@
     return isCompDirector ? '' : 'brewer-name-hidden';
   }
 
+  // Helper function to get beer name display
+  function getBeerNameDisplay(beerName) {
+    if (isCompDirector) {
+      return beerName || 'Unknown Beer';
+    }
+    return 'Hidden'; // Hidden for non-Comp Directors
+  }
+
   // Helper functions for ranking points calculation
   function getPointsForRanking(rankPosition) {
     // Point system: 1st=3pts, 2nd=2pts, 3rd=1pt, others=0pts
@@ -267,12 +275,12 @@
 
       filtered = filtered.filter(entry =>
         entry.entry_number?.toLowerCase().includes(query) ||
-        entry.beer_name?.toLowerCase().includes(query) ||
         entry.category_display?.toLowerCase().includes(query) ||
-        // Only allow member name/email search for Competition Directors
+        // Only allow member name/email/beer name search for Competition Directors
         (isCompDirector && (
           entry.member_name?.toLowerCase().includes(query) ||
-          entry.member_email?.toLowerCase().includes(query)
+          entry.member_email?.toLowerCase().includes(query) ||
+          entry.beer_name?.toLowerCase().includes(query)
         ))
       );
     }
@@ -879,7 +887,7 @@
       <input
         type="text"
         class="search-input"
-        placeholder={isCompDirector ? "Search by entry number, member, or beer name..." : "Search by entry number or beer name..."}
+        placeholder={isCompDirector ? "Search by entry number, member, or beer name..." : "Search by entry number or category..."}
         bind:value={searchQuery}
       />
       <select class="filter-select" bind:value={categoryFilter}>
@@ -948,7 +956,7 @@
                   <div class="{getBrewerNameClass()}">{getBrewerNameDisplay(entry.member_name)}</div>
                   <small class="{getBrewerNameClass()}">{getBrewerEmailDisplay(entry.member_email)}</small>
                 </td>
-                <td>{entry.beer_name || '-'}</td>
+                <td class="{getBrewerNameClass()}">{getBeerNameDisplay(entry.beer_name)}</td>
                 <td><span class="category-badge">{entry.category_display}</span></td>
                 <td>
                   <span style="font-weight: 600; color: {entry.ranking_points > 0 ? '#059669' : '#666'};">
@@ -1021,7 +1029,7 @@
             </div>
             <div style="margin-bottom: 1rem;">
               <div class="{getBrewerNameClass()}"><strong>{getBrewerNameDisplay(entry.member_name)}</strong></div>
-              <div>{entry.beer_name || 'No beer name'}</div>
+              <div class="{getBrewerNameClass()}">{getBeerNameDisplay(entry.beer_name)}</div>
               <span class="category-badge">{entry.category_display}</span>
               <div style="margin-top: 0.5rem;">
                 <span style="font-size: 0.875rem; color: #666;">Ranking Points: </span>


### PR DESCRIPTION
…erfaces

Privacy Controls Added:
- Judging dashboard: Hide beer names in all entry displays (desktop & mobile)
- Competition results page: Hide beer names in tables and cards, update search
- Simple scoresheet: Hide beer names in judge entry details
- BJCP scoresheet: Hide beer names in detailed scoresheet view

Implementation Details:
- Add getBeerNameDisplay() helper function to each interface
- Show 'Hidden' for non-Competition Directors, real names for Comp Directors
- Update search functionality to respect beer name privacy
- Maintain consistent styling with existing brewer name privacy controls

Security: Prevents identification of brewers through creative beer names like "James' IPA" while maintaining full functionality for authorized users.

🤖 Generated with [Claude Code](https://claude.ai/code)