### PR TITLE
Fix service worker installation preventing PWA recognition

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="icon" href="%sveltekit.assets%/JAX-Profile-Final-1.svg" type="image/svg+xml" />
 		<meta name="viewport" content="width=device-width" />
 		<meta name="theme-color" content="#1e3a5f" />
 		<link rel="manifest" href="/manifest.json" />

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -17,10 +17,18 @@ const ASSETS = [
 
 sw.addEventListener('install', (event) => {
   event.waitUntil(
-    caches
-      .open(CACHE)
-      .then((cache) => cache.addAll(ASSETS))
-      .then(() => sw.skipWaiting())
+    caches.open(CACHE).then(async (cache) => {
+      // Cache assets individually so one failure doesn't abort the whole install.
+      // A cold Cloud Run start or transient network blip on any single asset
+      // would otherwise prevent the service worker from ever becoming active.
+      await Promise.allSettled(
+        ASSETS.map((url) =>
+          cache.add(url).catch((err) => {
+            console.warn(`[SW] Failed to cache ${url}:`, err);
+          })
+        )
+      );
+    }).then(() => sw.skipWaiting())
   );
 });
 
@@ -51,9 +59,11 @@ sw.addEventListener('fetch', (event) => {
     return;
   }
 
-  // For cached assets: cache first
+  // For cached assets: cache first, fall back to network on miss
   if (ASSETS.includes(url.pathname)) {
-    event.respondWith(caches.match(event.request));
+    event.respondWith(
+      caches.match(event.request).then((cached) => cached || fetch(event.request))
+    );
     return;
   }
 


### PR DESCRIPTION
Two bugs were causing Chrome to create a shortcut instead of a PWA:

1. cache.addAll() is atomic — if any single asset fetch fails (network blip, Cloud Run cold start), the entire service worker installation aborts and the SW never becomes active. Chrome requires an active SW to install a PWA. Fixed by caching each asset individually with Promise.allSettled so partial failures are logged but don't block installation.

2. Fetch handler called event.respondWith(caches.match()) which resolves to undefined on a cache miss, causing requests to hang. Fixed with fallback to fetch() on cache miss.

Also fix favicon 404: app.html referenced favicon.png which doesn't exist in static/; updated to use the existing JAX SVG logo instead.