### PR TITLE
Officer signup management and event locking

### DIFF
--- a/add_event_locked_field.sql
+++ b/add_event_locked_field.sql
@@ -1,0 +1,60 @@
+-- Add `locked` flag to events
+-- When TRUE, members cannot create or modify their own signups for the event.
+-- Officers can still manage signups (add / remove) regardless of lock state.
+-- Run this in your Supabase SQL editor.
+
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS locked BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_events_locked ON events(locked);
+
+-- Block member-side INSERT / UPDATE / DELETE on event_signups when the parent
+-- event is locked. Officers continue to bypass via the existing
+-- "Officers can manage event signups" policy.
+DROP POLICY IF EXISTS "Members can insert own signup" ON event_signups;
+DROP POLICY IF EXISTS "Members can update own signup" ON event_signups;
+DROP POLICY IF EXISTS "Members can delete own signup" ON event_signups;
+
+CREATE POLICY "Members can insert own signup"
+    ON event_signups FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        member_id = auth.uid()
+        AND NOT EXISTS (
+            SELECT 1 FROM events
+            WHERE events.id = event_signups.event_id
+            AND events.locked = TRUE
+        )
+    );
+
+CREATE POLICY "Members can update own signup"
+    ON event_signups FOR UPDATE
+    TO authenticated
+    USING (
+        member_id = auth.uid()
+        AND NOT EXISTS (
+            SELECT 1 FROM events
+            WHERE events.id = event_signups.event_id
+            AND events.locked = TRUE
+        )
+    )
+    WITH CHECK (
+        member_id = auth.uid()
+        AND NOT EXISTS (
+            SELECT 1 FROM events
+            WHERE events.id = event_signups.event_id
+            AND events.locked = TRUE
+        )
+    );
+
+CREATE POLICY "Members can delete own signup"
+    ON event_signups FOR DELETE
+    TO authenticated
+    USING (
+        member_id = auth.uid()
+        AND NOT EXISTS (
+            SELECT 1 FROM events
+            WHERE events.id = event_signups.event_id
+            AND events.locked = TRUE
+        )
+    );

--- a/src/lib/components/EventForm.svelte
+++ b/src/lib/components/EventForm.svelte
@@ -19,6 +19,7 @@
   let signupDeadlineTime = toTimeInput(initial.signup_deadline, '18:00');
   let maxAttendees = initial.max_attendees ?? '';
   let isActive = initial.active ?? true;
+  let isLocked = initial.locked ?? false;
 
   let errors = {};
 
@@ -87,7 +88,8 @@
       end_date: combine(endDate, endTime),
       signup_deadline: combine(signupDeadlineDate, signupDeadlineTime),
       max_attendees: maxAttendees === '' ? null : Number(maxAttendees),
-      active: isActive
+      active: isActive,
+      locked: isLocked
     };
 
     dispatch('submit', payload);
@@ -185,6 +187,11 @@
   <label class="checkbox-row">
     <input type="checkbox" bind:checked={isActive} />
     <span>Active (visible to members)</span>
+  </label>
+
+  <label class="checkbox-row">
+    <input type="checkbox" bind:checked={isLocked} />
+    <span>Locked (members can't add or change their signup — at capacity)</span>
   </label>
 
   <div class="form-actions">

--- a/src/lib/stores/eventManagementStore.js
+++ b/src/lib/stores/eventManagementStore.js
@@ -165,6 +165,63 @@ export async function deleteEvent(eventId) {
 }
 
 // =============================================
+// Officer signup mutations
+// =============================================
+
+export async function addMemberSignup(eventId, memberId, { bringing, notes } = {}) {
+    if (!eventId || !memberId) throw new Error('Event and member are required.');
+
+    const { data, error: insertError } = await supabase
+        .from('event_signups')
+        .insert([
+            {
+                event_id: eventId,
+                member_id: memberId,
+                bringing: bringing?.trim() ? bringing.trim() : null,
+                notes: notes?.trim() ? notes.trim() : null
+            }
+        ])
+        .select()
+        .single();
+
+    if (insertError) {
+        if (insertError.code === '23505') {
+            throw new Error('That member is already signed up for this event.');
+        }
+        throw insertError;
+    }
+
+    return data;
+}
+
+export async function removeSignup(signupId) {
+    if (!signupId) throw new Error('Signup id is required.');
+
+    const { error: deleteError } = await supabase
+        .from('event_signups')
+        .delete()
+        .eq('id', signupId);
+
+    if (deleteError) throw deleteError;
+}
+
+export async function loadSignupCandidates(eventId) {
+    if (!eventId) return [];
+
+    const [{ data: members, error: membersError }, { data: existing, error: existingError }] =
+        await Promise.all([
+            supabase.from('members').select('id, name, email').order('name', { ascending: true }),
+            supabase.from('event_signups').select('member_id').eq('event_id', eventId)
+        ]);
+
+    if (membersError) throw membersError;
+    if (existingError) throw existingError;
+
+    const taken = new Set((existing || []).map((s) => s.member_id));
+    return (members || []).filter((m) => !taken.has(m.id));
+}
+
+// =============================================
 // Member signup mutations
 // =============================================
 
@@ -243,6 +300,9 @@ export const eventManagementStore = {
     createEvent,
     updateEvent,
     deleteEvent,
+    addMemberSignup,
+    removeSignup,
+    loadSignupCandidates,
     upsertMySignup,
     removeMySignup,
     loadMySignup,

--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -74,7 +74,13 @@
               <Card>
                 <div class="event-header">
                   <h3 class="event-name">{event.name}</h3>
-                  <Badge variant="primary">Upcoming</Badge>
+                  {#if event.locked}
+                    <Badge variant="warning">Locked</Badge>
+                  {:else if event.max_attendees && event.signup_count >= event.max_attendees}
+                    <Badge variant="warning">Full</Badge>
+                  {:else}
+                    <Badge variant="primary">Upcoming</Badge>
+                  {/if}
                 </div>
 
                 <div class="event-meta">

--- a/src/routes/events/[id]/+page.svelte
+++ b/src/routes/events/[id]/+page.svelte
@@ -42,7 +42,8 @@
   $: isFull = event?.max_attendees && signups.length >= event.max_attendees && !mySignup;
   $: isPast = event && new Date(event.event_date) < new Date();
   $: signupClosed = event?.signup_deadline && new Date(event.signup_deadline) < new Date();
-  $: canSignUp = isLoggedIn && !isPast && !signupClosed && event?.active;
+  $: isLocked = !!event?.locked;
+  $: canSignUp = isLoggedIn && !isPast && !signupClosed && !isLocked && event?.active;
 
   onMount(async () => {
     await refresh();
@@ -164,8 +165,12 @@
           <Badge variant="secondary">Past Event</Badge>
         {:else if !event.active}
           <Badge variant="warning">Inactive</Badge>
+        {:else if isLocked}
+          <Badge variant="warning">Locked</Badge>
         {:else if signupClosed}
           <Badge variant="warning">Signups Closed</Badge>
+        {:else if isFull}
+          <Badge variant="warning">Full</Badge>
         {:else}
           <Badge variant="primary">Open</Badge>
         {/if}
@@ -226,6 +231,11 @@
         <p class="note">This event has already happened.</p>
       {:else if !event.active}
         <p class="note">This event is not currently accepting signups.</p>
+      {:else if isLocked && !mySignup}
+        <p class="note">
+          Signups are locked for this event. Reach out to an officer if you need to
+          be added.
+        </p>
       {:else if signupClosed && !mySignup}
         <p class="note">The signup deadline has passed.</p>
       {:else if isFull}
@@ -243,16 +253,22 @@
           {#if mySignup.notes}
             <p><strong>Notes:</strong> {mySignup.notes}</p>
           {/if}
-          <div class="signup-actions">
-            <Button variant="secondary" size="sm" on:click={() => (editing = true)}>
-              <Pencil size={14} />
-              Edit
-            </Button>
-            <Button variant="danger" size="sm" on:click={handleCancel} disabled={isSaving}>
-              <Trash2 size={14} />
-              Cancel signup
-            </Button>
-          </div>
+          {#if isLocked}
+            <p class="note">
+              Signups are locked. Contact an officer if you need to make changes.
+            </p>
+          {:else}
+            <div class="signup-actions">
+              <Button variant="secondary" size="sm" on:click={() => (editing = true)}>
+                <Pencil size={14} />
+                Edit
+              </Button>
+              <Button variant="danger" size="sm" on:click={handleCancel} disabled={isSaving}>
+                <Trash2 size={14} />
+                Cancel signup
+              </Button>
+            </div>
+          {/if}
         </div>
       {:else}
         <form

--- a/src/routes/officers/manage-events/+page.svelte
+++ b/src/routes/officers/manage-events/+page.svelte
@@ -29,7 +29,9 @@
     Printer,
     Play,
     Pause,
-    RefreshCw
+    RefreshCw,
+    Lock,
+    Unlock
   } from 'lucide-svelte';
   import toast from 'svelte-french-toast';
   import { showConfirm } from '$lib/stores/confirmDialog.js';
@@ -92,6 +94,15 @@
     try {
       await updateEvent(event.id, { active: !event.active });
       toast.success(`Event ${event.active ? 'deactivated' : 'activated'}.`);
+    } catch (err) {
+      toast.error(`Error: ${err.message}`);
+    }
+  }
+
+  async function toggleLocked(event) {
+    try {
+      await updateEvent(event.id, { locked: !event.locked });
+      toast.success(`Event ${event.locked ? 'unlocked' : 'locked'}.`);
     } catch (err) {
       toast.error(`Error: ${err.message}`);
     }
@@ -194,6 +205,11 @@
                 {:else}
                   <Badge variant="primary">Active</Badge>
                 {/if}
+                {#if event.locked}
+                  <Badge variant="warning">Locked</Badge>
+                {:else if event.max_attendees && event.signup_count >= event.max_attendees}
+                  <Badge variant="warning">At capacity</Badge>
+                {/if}
               </div>
 
               <div class="event-meta">
@@ -244,6 +260,15 @@
                 {:else}
                   <Play size={14} />
                   Activate
+                {/if}
+              </Button>
+              <Button variant="secondary" size="sm" on:click={() => toggleLocked(event)}>
+                {#if event.locked}
+                  <Unlock size={14} />
+                  Unlock
+                {:else}
+                  <Lock size={14} />
+                  Lock
                 {/if}
               </Button>
               <Button variant="danger" size="sm" on:click={() => handleDelete(event)}>

--- a/src/routes/officers/manage-events/signups/[id]/+page.svelte
+++ b/src/routes/officers/manage-events/signups/[id]/+page.svelte
@@ -3,7 +3,13 @@
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
   import { userProfile } from '$lib/stores/userProfile.js';
-  import { loadEvent, loadEventSignups } from '$lib/stores/eventManagementStore.js';
+  import {
+    loadEvent,
+    loadEventSignups,
+    loadSignupCandidates,
+    addMemberSignup,
+    removeSignup
+  } from '$lib/stores/eventManagementStore.js';
   import {
     Hero,
     Container,
@@ -11,9 +17,13 @@
     EmptyState,
     Card,
     Button,
-    Badge
+    Badge,
+    FormInput,
+    FormSelect
   } from '$lib/components/ui';
-  import { ArrowLeft, Printer, Pencil } from 'lucide-svelte';
+  import { ArrowLeft, Printer, Pencil, UserPlus, Trash2 } from 'lucide-svelte';
+  import toast from 'svelte-french-toast';
+  import { showConfirm } from '$lib/stores/confirmDialog.js';
 
   $: if ($userProfile && !$userProfile.is_officer) {
     goto('/');
@@ -23,8 +33,21 @@
 
   let event = null;
   let signups = [];
+  let candidates = [];
   let isLoading = true;
   let loadError = null;
+
+  let selectedMemberId = '';
+  let bringing = '';
+  let notes = '';
+  let isAdding = false;
+
+  $: capacityReached =
+    !!event?.max_attendees && signups.length >= event.max_attendees;
+  $: candidateOptions = candidates.map((m) => ({
+    value: m.id,
+    label: m.email ? `${m.name} (${m.email})` : m.name
+  }));
 
   onMount(async () => {
     await refresh();
@@ -36,10 +59,56 @@
     try {
       event = await loadEvent(eventId);
       signups = await loadEventSignups(eventId);
+      candidates = await loadSignupCandidates(eventId);
     } catch (err) {
       loadError = err.message || 'Failed to load event';
     } finally {
       isLoading = false;
+    }
+  }
+
+  async function handleAddMember() {
+    if (!selectedMemberId) {
+      toast.error('Pick a member to add.');
+      return;
+    }
+
+    if (capacityReached) {
+      const confirmed = await showConfirm(
+        `This event is at its capacity of ${event.max_attendees}. Add this member anyway?`,
+        'Over capacity'
+      );
+      if (!confirmed) return;
+    }
+
+    isAdding = true;
+    try {
+      await addMemberSignup(eventId, selectedMemberId, { bringing, notes });
+      toast.success('Member added.');
+      selectedMemberId = '';
+      bringing = '';
+      notes = '';
+      await refresh();
+    } catch (err) {
+      toast.error(`Error: ${err.message}`);
+    } finally {
+      isAdding = false;
+    }
+  }
+
+  async function handleRemove(signup) {
+    const confirmed = await showConfirm(
+      `Remove ${signup.member_name} from this event?`,
+      'Remove signup?'
+    );
+    if (!confirmed) return;
+
+    try {
+      await removeSignup(signup.id);
+      toast.success('Signup removed.');
+      await refresh();
+    } catch (err) {
+      toast.error(`Error: ${err.message}`);
     }
   }
 
@@ -107,9 +176,66 @@
       </Button>
     </EmptyState>
   {:else}
+    <div class="add-member screen-only">
+      <Card accent accentColor="primary">
+        <h2 class="add-member-title">Add a member</h2>
+        <p class="add-member-help">
+          Manually sign up a member who can't (or hasn't) RSVP'd online.
+        </p>
+
+        {#if candidates.length === 0}
+          <p class="muted">All current members are already signed up.</p>
+        {:else}
+          <div class="add-form">
+            <FormSelect
+              id="add-member"
+              label="Member"
+              placeholder="Choose a member..."
+              bind:value={selectedMemberId}
+              options={candidateOptions}
+            />
+            <FormInput
+              id="add-bringing"
+              label="Bringing (optional)"
+              bind:value={bringing}
+              placeholder="e.g. keg of IPA"
+            />
+            <FormInput
+              id="add-notes"
+              label="Notes (optional)"
+              bind:value={notes}
+            />
+            <div class="add-actions">
+              <Button
+                variant="primary"
+                on:click={handleAddMember}
+                disabled={isAdding || !selectedMemberId}
+              >
+                <UserPlus size={14} />
+                {isAdding ? 'Adding...' : 'Add to event'}
+              </Button>
+              {#if capacityReached}
+                <span class="capacity-warning">At capacity ({signups.length} / {event.max_attendees})</span>
+              {/if}
+            </div>
+          </div>
+        {/if}
+      </Card>
+    </div>
+
     <div class="print-sheet">
       <header class="sheet-header">
-        <h1 class="sheet-title">{event.name}</h1>
+        <div class="sheet-title-row">
+          <h1 class="sheet-title">{event.name}</h1>
+          <div class="sheet-badges screen-only">
+            {#if event.locked}
+              <Badge variant="warning">Locked</Badge>
+            {/if}
+            {#if capacityReached}
+              <Badge variant="warning">At capacity</Badge>
+            {/if}
+          </div>
+        </div>
         <div class="sheet-meta">
           <div><strong>When:</strong> {formatDate(event.event_date)}</div>
           {#if event.location}
@@ -140,6 +266,7 @@
                   <th class="col-contact">Contact</th>
                   <th>Notes</th>
                   <th class="col-check">Checked&nbsp;in</th>
+                  <th class="col-actions screen-only-cell">Actions</th>
                 </tr>
               </thead>
               <tbody>
@@ -155,6 +282,12 @@
                     </td>
                     <td>{s.notes || ''}</td>
                     <td class="col-check"></td>
+                    <td class="col-actions screen-only-cell">
+                      <Button variant="danger" size="sm" on:click={() => handleRemove(s)}>
+                        <Trash2 size={14} />
+                        Remove
+                      </Button>
+                    </td>
                   </tr>
                 {/each}
               </tbody>
@@ -184,6 +317,61 @@
     gap: var(--space-2);
   }
 
+  .add-member {
+    margin: var(--space-4) 0 var(--space-6);
+  }
+
+  .add-member-title {
+    font-family: var(--font-family-display);
+    font-size: var(--font-size-xl);
+    color: var(--color-brand-primary);
+    margin: 0 0 var(--space-2);
+  }
+
+  .add-member-help {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    margin: 0 0 var(--space-4);
+  }
+
+  .add-form {
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr;
+    gap: var(--space-4);
+  }
+
+  .add-actions {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+  }
+
+  :global(.add-actions .btn) {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .capacity-warning {
+    color: var(--color-warning);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+  }
+
+  .muted {
+    color: var(--color-text-tertiary);
+    font-size: var(--font-size-sm);
+    margin: 0;
+  }
+
+  @media (max-width: 720px) {
+    .add-form {
+      grid-template-columns: 1fr;
+    }
+  }
+
   .print-sheet {
     margin: var(--space-4) 0 var(--space-16);
   }
@@ -192,11 +380,36 @@
     margin-bottom: var(--space-5);
   }
 
+  .sheet-title-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+  }
+
+  .sheet-badges {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
   .sheet-title {
     font-family: var(--font-family-display);
     font-size: var(--font-size-3xl);
     color: var(--color-brand-primary);
-    margin: 0 0 var(--space-3);
+    margin: 0;
+  }
+
+  .col-actions {
+    width: 8em;
+    text-align: center;
+  }
+
+  :global(.col-actions .btn) {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
   }
 
   .sheet-meta {
@@ -268,6 +481,10 @@
 
   @media print {
     .screen-only {
+      display: none !important;
+    }
+
+    .screen-only-cell {
       display: none !important;
     }
 


### PR DESCRIPTION
## Summary
- Officers can manually add members to an event from the signups page via a dropdown of eligible members; existing signups can be removed inline.
- Events gain a `locked` flag, toggleable from the manage-events list and the event form. When locked, members cannot create or modify their own signups; officer overrides still work.
- Member-facing event pages surface `Locked` / `Full` badges and explain the locked state to anyone already signed up.

## Test plan
- [ ] Run `add_event_locked_field.sql` in Supabase, then verify the `locked` column exists on `events` and the updated RLS policies are in place.
- [ ] As an officer, on the manage-events list: lock and unlock an event and confirm the badge and RLS gating change accordingly.
- [ ] As an officer, on an event's signups page: add a member via the dropdown, remove a signup, and confirm the over-capacity confirm prompt appears when applicable.
- [ ] As a member with no signup: confirm a locked event blocks new signups and shows the "contact an officer" message.
- [ ] As a member with an existing signup: confirm a locked event hides the edit/cancel buttons but still shows your signup info.
- [ ] Print a signup sheet and confirm the new "Actions" column / Add card / screen-only badges are not printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)