### PR TITLE
chore(ui): migrate inline styles to design-system tokens (#64)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+# .github/workflows/lint.yml
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - develop
+  workflow_dispatch:
+
+jobs:
+  inline-styles:
+    name: Inline style guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      # The guard has no dependencies, so a checkout + Node is all it needs.
+      - name: Check for hard-coded inline styles (issue #64)
+        run: node scripts/check-inline-styles.js

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint:css": "stylelint 'src/**/*.{css,svelte}'"
+    "lint:css": "stylelint 'src/**/*.{css,svelte}'",
+    "lint:inline": "node scripts/check-inline-styles.js"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.0.0",

--- a/scripts/check-inline-styles.js
+++ b/scripts/check-inline-styles.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Guards against new inline `style="..."` attributes that hard-code raw values
+ * and bypass the design system (see issue #64).
+ *
+ * A `style="..."` attribute is only allowed when everything left over after
+ * removing `var(--token)` references and `{...}` dynamic expressions is free of
+ * raw values — i.e. it contains no hex colour and no raw px/rem/em length.
+ * That permits token-only inline styles (`color: var(--color-text-secondary)`)
+ * and dynamic custom-property bindings (`--progress: {pct}%`), while flagging
+ * hard-coded values like `font-size: 0.9rem` or `color: #1e40af`.
+ *
+ * Usage: node scripts/check-inline-styles.js
+ * Exits non-zero (and lists offenders) when a violation is found.
+ */
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const ROOTS = ['src/routes', 'src/lib'];
+
+const files = execSync(
+  `find ${ROOTS.join(' ')} -name '*.svelte' -type f`,
+  { encoding: 'utf8' }
+)
+  .split('\n')
+  .filter(Boolean);
+
+// Matches both style="..." and style='...' attributes.
+const STYLE_ATTR = /style=(?:"([^"]*)"|'([^']*)')/g;
+const RAW_HEX = /#[0-9a-fA-F]{3,8}\b/;
+const RAW_LENGTH = /(?<![\w-])\d*\.?\d+(px|rem|em)\b/;
+
+const offenders = [];
+
+for (const file of files) {
+  const lines = readFileSync(file, 'utf8').split('\n');
+  lines.forEach((line, idx) => {
+    for (const match of line.matchAll(STYLE_ATTR)) {
+      const value = match[1] ?? match[2] ?? '';
+      // Drop tokens and dynamic expressions; only raw literals should remain.
+      const stripped = value
+        .replace(/var\(\s*--[^)]*\)/g, '')
+        .replace(/\{[^}]*\}/g, '');
+      if (RAW_HEX.test(stripped) || RAW_LENGTH.test(stripped)) {
+        offenders.push({ file, line: idx + 1, value });
+      }
+    }
+  });
+}
+
+if (offenders.length > 0) {
+  console.error(
+    `✗ Found ${offenders.length} inline style attribute(s) with hard-coded values.\n` +
+      `  Move these into a scoped class or design-system token (see issue #64).\n`
+  );
+  for (const o of offenders) {
+    console.error(`  ${o.file}:${o.line}  style="${o.value}"`);
+  }
+  process.exit(1);
+}
+
+console.log('✓ No inline styles with hard-coded values found.');

--- a/src/app.css
+++ b/src/app.css
@@ -42,8 +42,10 @@
   --color-info-hover: #1d4ed8;
   --color-info-light: rgba(37, 99, 235, 0.1);
   --color-info-bg: #dbeafe;
+  --color-info-bg-subtle: #eff6ff;
   --color-info-accent: #3b82f6;
   --color-info-cyan: #0891b2;
+  --color-accent-indigo: #6366f1;
 
   /* Medal Colors (semantic, not brand) */
   --color-medal-gold: #ffd700;
@@ -417,6 +419,31 @@ ol[role="list"] {
   display: inline-block;
   vertical-align: middle;
   margin-right: var(--space-1);
+}
+
+/* Icon that follows its label text (gap on the left). */
+.icon-inline-after {
+  display: inline-block;
+  vertical-align: text-bottom;
+  margin-left: var(--space-1);
+}
+
+/* Icon with a larger trailing gap. */
+.icon-inline-lg {
+  display: inline-block;
+  vertical-align: text-bottom;
+  margin-right: var(--space-2);
+}
+
+/* Continuously spinning icon (loading indicators). */
+.icon-spin {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* Visually hidden but accessible */

--- a/src/routes/competitions/results/+page.svelte
+++ b/src/routes/competitions/results/+page.svelte
@@ -852,7 +852,7 @@
       <!-- Results Summary -->
       {#if !isLoadingResults && results.length > 0}
         <div class="results-summary">
-          <h2 style="margin: 0 0 1.5rem 0; color: var(--color-text-primary);">{selectedCompetition.name} - Results Summary</h2>
+          <h2 style="margin: 0 0 var(--space-6) 0; color: var(--color-text-primary);">{selectedCompetition.name} - Results Summary</h2>
           <div class="summary-grid">
             <div class="summary-item">
               <div class="summary-label">Total Entries</div>

--- a/src/routes/competitions/submit-entry/+page.svelte
+++ b/src/routes/competitions/submit-entry/+page.svelte
@@ -383,7 +383,7 @@
             disabled={!canSubmit || submitSuccess}
           >
             {#if submitting}
-              <RotateCcw size={18} strokeWidth={2} style="display: inline-block; vertical-align: text-bottom; margin-right: 0.25rem; animation: spin 1s linear infinite;" />
+              <RotateCcw size={18} strokeWidth={2} class="icon-inline icon-spin" />
               Submitting...
             {:else if submitSuccess}
               <CheckCircle size={18} strokeWidth={2} class="icon-inline" />

--- a/src/routes/judge/competition/[id]/+page.svelte
+++ b/src/routes/judge/competition/[id]/+page.svelte
@@ -795,7 +795,7 @@
   {#if !$isJudging}
     <LoadingSpinner message="Starting judging session..." />
   {:else if !$currentEntry}
-    <div style="text-align: center; padding: 3rem;">
+    <div style="text-align: center; padding: var(--space-12);">
       <h2>No entries to judge</h2>
       <Button variant="secondary" on:click={() => goto('/judge')}>
         Back to Judge Portal
@@ -1021,7 +1021,7 @@
               disabled={isSaving}
             >
               Next Entry
-              <ArrowRight size={18} strokeWidth={2} style="display: inline-block; vertical-align: text-bottom; margin-left: 0.25rem;" />
+              <ArrowRight size={18} strokeWidth={2} class="icon-inline-after" />
             </Button>
           {:else}
             <button

--- a/src/routes/judge/competition/[id]/rankings/+page.svelte
+++ b/src/routes/judge/competition/[id]/rankings/+page.svelte
@@ -889,7 +889,7 @@
   <!-- Header -->
   <div class="header">
     <h1>
-      <Trophy size={32} strokeWidth={2} style="display: inline-block; vertical-align: text-bottom; margin-right: 0.5rem;" />
+      <Trophy size={32} strokeWidth={2} class="icon-inline-lg" />
       Category Rankings
     </h1>
     <p>Rank entries within each category based on your judging scores</p>
@@ -985,12 +985,12 @@
         {/if}
 
         {#if competitionType === 'intraclub'}
-          <div class="validation-warning" style="background: #f0f9ff; border-color: var(--color-info-accent);">
+          <div class="validation-warning" style="background: var(--color-info-bg-subtle); border-color: var(--color-info-accent);">
             <h4>
               <Info size={20} strokeWidth={2} class="icon-inline" />
               Intraclub Competition Rules
             </h4>
-            <div style="color: #1e40af; font-size: 0.875rem;">
+            <div style="color: var(--color-info-hover); font-size: var(--font-size-sm);">
               You cannot rank your own entries in positions 1-3. Your entries are marked with a blue indicator.
             </div>
           </div>
@@ -1022,7 +1022,7 @@
                     Entry #{ranking.entry.entry_number}
                     {#if isOwnEntry(ranking.entry)}
                       <span class="own-entry-indicator">
-                        <User size={12} strokeWidth={2} style="display: inline-block; vertical-align: middle; margin-right: 0.125rem;" />
+                        <User size={12} strokeWidth={2} class="icon-inline-middle" />
                         Your Entry
                       </span>
                     {/if}
@@ -1054,7 +1054,7 @@
                   </div>
 
                   {#if ranking.entry.private_notes}
-                    <div class="detail-text" style="margin-top: 0.5rem; color: #6366f1; font-style: italic;">
+                    <div class="detail-text" style="margin-top: var(--space-2); color: var(--color-accent-indigo); font-style: italic;">
                       <MessageCircle size={14} strokeWidth={2} class="icon-inline-middle" />
                       {ranking.entry.private_notes}
                     </div>

--- a/src/routes/judge/competition/[id]/scoresheet/+page.svelte
+++ b/src/routes/judge/competition/[id]/scoresheet/+page.svelte
@@ -644,6 +644,20 @@
       width: 100%;
     }
   }
+
+  .section-hint {
+    font-size: 0.9rem;
+    margin-bottom: var(--space-2);
+    font-style: italic;
+  }
+
+  .comments-textarea.is-tall {
+    min-height: 100px;
+  }
+
+  .comments-textarea.is-taller {
+    min-height: 120px;
+  }
 </style>
 
 <Hero
@@ -718,7 +732,7 @@
           </div>
         </div>
         <div class="section-content">
-          <p style="font-size: 0.9rem; margin-bottom: 0.5rem; font-style: italic;">
+          <p class="section-hint">
             Comment on malt, hops, esters, and other aromatics
           </p>
           <textarea
@@ -746,7 +760,7 @@
           </div>
         </div>
         <div class="section-content">
-          <p style="font-size: 0.9rem; margin-bottom: 0.5rem; font-style: italic;">
+          <p class="section-hint">
             Comment on color, clarity, and head (retention, color, and texture)
           </p>
           <textarea
@@ -774,12 +788,11 @@
           </div>
         </div>
         <div class="section-content">
-          <p style="font-size: 0.9rem; margin-bottom: 0.5rem; font-style: italic;">
+          <p class="section-hint">
             Comment on malt, hops, fermentation characteristics, balance, finish/aftertaste, and other flavor characteristics
           </p>
           <textarea
-            class="comments-textarea"
-            style="min-height: 100px;"
+            class="comments-textarea is-tall"
             bind:value={scoresheetData.flavor_comments}
             on:input={handleInputChange}
             placeholder="Describe the flavor profile, balance, and finish..."
@@ -803,7 +816,7 @@
           </div>
         </div>
         <div class="section-content">
-          <p style="font-size: 0.9rem; margin-bottom: 0.5rem; font-style: italic;">
+          <p class="section-hint">
             Comment on body, carbonation, warmth, creaminess, astringency, and other palate sensations
           </p>
           <textarea
@@ -831,12 +844,11 @@
           </div>
         </div>
         <div class="section-content">
-          <p style="font-size: 0.9rem; margin-bottom: 0.5rem; font-style: italic;">
+          <p class="section-hint">
             Comment on overall drinking pleasure associated with entry, give suggestions for improvement
           </p>
           <textarea
-            class="comments-textarea"
-            style="min-height: 120px;"
+            class="comments-textarea is-taller"
             bind:value={scoresheetData.overall_comments}
             on:input={handleInputChange}
             placeholder="Overall assessment and suggestions for improvement..."
@@ -968,7 +980,7 @@
           on:click={navigateToNext}
         >
           Next Entry
-          <ArrowRight size={18} strokeWidth={2} style="display: inline-block; vertical-align: text-bottom; margin-left: 0.25rem;" />
+          <ArrowRight size={18} strokeWidth={2} class="icon-inline-after" />
         </Button>
       {:else}
         <Button

--- a/src/routes/officers/manage-competitions/create/+page.svelte
+++ b/src/routes/officers/manage-competitions/create/+page.svelte
@@ -644,7 +644,7 @@
           />
           
           {#if selectedCategories.length > 0}
-            <div style="margin-top: 1.5rem;">
+            <div style="margin-top: var(--space-6);">
               <RankingGroupManager
                 bind:rankingGroups
                 {selectedCategories}

--- a/src/routes/officers/manage-competitions/edit/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/edit/[id]/+page.svelte
@@ -826,7 +826,7 @@
             />
             
             {#if selectedCategories.length > 0}
-              <div style="margin-top: 1.5rem;">
+              <div style="margin-top: var(--space-6);">
                 <RankingGroupManager
                   bind:rankingGroups
                   {selectedCategories}

--- a/src/routes/officers/manage-competitions/entries/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/entries/[id]/+page.svelte
@@ -712,7 +712,7 @@ function printLabels() {
           
           <div class="judge-info">
             <strong>Judge Name:</strong> <span class="judge-line"></span>
-            <strong style="margin-left: 40px;">Signature:</strong> <span class="judge-line"></span>
+            <strong style="margin-left: var(--space-10);">Signature:</strong> <span class="judge-line"></span>
           </div>
           
           <div class="entries-section">
@@ -1182,6 +1182,11 @@ function printLabels() {
   .modal-button:hover {
     background: #e63600;
   }
+
+  .category-sub {
+    color: var(--color-text-secondary);
+    font-size: 0.8rem;
+  }
 </style>
 
 <!-- Access Denied Modal -->
@@ -1449,7 +1454,7 @@ function printLabels() {
                     {entry.bjcp_category?.category_number || ''}{entry.bjcp_category?.subcategory_letter || ''}
                   </span>
                   {#if entry.bjcp_category?.subcategory_name}
-                    <br><small style="color: var(--color-text-secondary); font-size: 0.8rem;">{entry.bjcp_category.subcategory_name}</small>
+                    <br><small class="category-sub">{entry.bjcp_category.subcategory_name}</small>
                   {/if}
                 </div>
               </div>

--- a/src/routes/officers/manage-competitions/judges/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/judges/[id]/+page.svelte
@@ -651,6 +651,25 @@
       flex-direction: column;
     }
   }
+
+  .empty-hint {
+    padding: var(--space-6);
+    color: var(--color-text-secondary);
+    font-size: 0.95rem;
+  }
+
+  .input-compact {
+    padding: 0.4rem 0.6rem;
+  }
+
+  .field-narrow {
+    max-width: 120px;
+  }
+
+  .muted-sm {
+    font-size: 0.85rem;
+    color: var(--color-text-secondary);
+  }
 </style>
 
 <Hero
@@ -708,7 +727,7 @@
       {#if $isLoadingTables}
         <LoadingSpinner message="Loading tables..." />
       {:else if tables.length === 0 && !showAddTableForm}
-        <div style="padding: 1.5rem 1.5rem; color: var(--color-text-secondary, var(--color-gray-500)); font-size: 0.95rem;">
+        <div class="empty-hint">
           No judging tables yet. Add tables to assign judges and entries to specific tables.
         </div>
       {:else}
@@ -719,8 +738,7 @@
                 <div class="inline-edit-form">
                   <span style="font-weight:600; color: var(--color-gray-700); white-space: nowrap;">Table {table.table_number}:</span>
                   <input
-                    class="form-control"
-                    style="padding: 0.4rem 0.6rem;"
+                    class="form-control input-compact"
                     bind:value={editingTableName}
                     on:keydown={(e) => { if (e.key === 'Enter') saveEditTable(table.id); if (e.key === 'Escape') cancelEditTable(); }}
                   />
@@ -752,7 +770,7 @@
         <div class="add-table-form">
           <h4>New Judging Table</h4>
           <div class="form-row">
-            <div class="form-group" style="max-width: 120px;">
+            <div class="form-group field-narrow">
               <label for="table-number">Table #</label>
               <input
                 id="table-number"
@@ -790,7 +808,7 @@
     <div class="section-card">
       <div class="section-header">
         <h3>Assigned Judges ({$judgeList.length})</h3>
-        <div style="display:flex; gap:0.75rem; align-items:center; flex-wrap:wrap;">
+        <div style="display: flex; gap: var(--space-3); align-items: center; flex-wrap: wrap;">
           {#if competition.competition_type === 'intraclub' && availableJudges.length > 0}
             <Button
               variant="primary"
@@ -827,13 +845,13 @@
                 <p>{judgeAssignment.judge?.email}</p>
                 <span class="role-badge">{getRoleDisplayName(judgeAssignment.judge_role)}</span>
                 {#if judgeAssignment.assignment_notes}
-                  <p style="margin-top: 0.5rem; font-style: italic;">{judgeAssignment.assignment_notes}</p>
+                  <p style="margin-top: var(--space-2); font-style: italic;">{judgeAssignment.assignment_notes}</p>
                 {/if}
                 <!-- Table selector -->
                 <div class="judge-table-selector">
                   <label for="judge-table-{judgeAssignment.id}">Table:</label>
                   {#if tables.length === 0}
-                    <span style="font-size:0.85rem; color: var(--color-text-secondary, var(--color-gray-500));">No tables created yet</span>
+                    <span class="muted-sm">No tables created yet</span>
                   {:else}
                     <select
                       id="judge-table-{judgeAssignment.id}"
@@ -946,7 +964,7 @@
     </div>
 
     {#if $judgeError}
-      <div style="background: var(--color-danger-bg); color: var(--color-danger); padding: 1rem; border-radius: var(--radius-sm); margin-top: 1rem;">
+      <div style="background: var(--color-danger-bg); color: var(--color-danger); padding: var(--space-4); border-radius: var(--radius-sm); margin-top: var(--space-4);">
         Error: {$judgeError}
       </div>
     {/if}

--- a/src/routes/officers/manage-competitions/judging-dashboard/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/judging-dashboard/[id]/+page.svelte
@@ -999,6 +999,51 @@
     border-radius: 3px;
     font-size: 0.875rem;
   }
+
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: var(--space-8);
+  }
+
+  .score-value {
+    font-size: 1.2rem;
+    font-weight: 600;
+  }
+
+  .score-sublabel {
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+    margin-top: var(--space-1);
+  }
+
+  .score-highlight {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: var(--color-success);
+  }
+
+  .category-sub {
+    color: var(--color-text-secondary);
+    font-size: 0.8rem;
+  }
+
+  .success-panel {
+    background: var(--color-success-bg);
+    border: 1px solid var(--color-success);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    margin-bottom: var(--space-4);
+  }
+
+  .success-panel.is-note {
+    font-size: var(--font-size-sm);
+    color: var(--color-success-bg-strong);
+  }
+
+  .progress-bar--inline {
+    width: 120px;
+  }
 </style>
 
 {#if isLoading}
@@ -1110,7 +1155,7 @@
           <h2 class="section-title">Judging Overview</h2>
         </div>
         <div class="section-content">
-          <div style="margin-bottom: 2rem;">
+          <div style="margin-bottom: var(--space-8);">
             <h3>Overall Progress</h3>
             <div class="progress-bar">
               <div class="progress-fill" style="width: {judgingStats.completionPercentage}%"></div>
@@ -1120,12 +1165,12 @@
             </p>
           </div>
 
-          <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem;">
+          <div class="summary-grid">
             <div>
               {#if competition?.category_system === 'custom' && rankingGroups.length > 0}
                 <h4>Custom Ranking Groups ({rankingGroups.length})</h4>
                 {#each rankingGroups as group}
-                  <div style="display: flex; justify-content: space-between; margin-bottom: 0.5rem;">
+                  <div style="display: flex; justify-content: space-between; margin-bottom: var(--space-2);">
                     <span>{group.group_name}</span>
                     <span>{getGroupEntryCount(group)} entries</span>
                   </div>
@@ -1133,7 +1178,7 @@
               {:else}
                 <h4>Categories ({categories.length})</h4>
                 {#each categories as category}
-                  <div style="display: flex; justify-content: space-between; margin-bottom: 0.5rem;">
+                  <div style="display: flex; justify-content: space-between; margin-bottom: var(--space-2);">
                     <span>{category.name}</span>
                     <span>{category.entryCount} entries</span>
                   </div>
@@ -1172,7 +1217,7 @@
                   <td>
                     <div>
                       <div style="font-weight: 600;">{judge.judge?.name}</div>
-                      <div style="font-size: 0.875rem; color: var(--color-text-secondary);">{judge.judge?.email}</div>
+                      <div style="font-size: var(--font-size-sm); color: var(--color-text-secondary);">{judge.judge?.email}</div>
                     </div>
                   </td>
                   <td>
@@ -1181,7 +1226,7 @@
                     </span>
                   </td>
                   <td>
-                    <div class="progress-bar" style="width: 120px;">
+                    <div class="progress-bar progress-bar--inline">
                       <div class="progress-fill" style="width: {progress.percentage}%"></div>
                     </div>
                     <div class="progress-text">{progress.percentage}%</div>
@@ -1257,7 +1302,7 @@
                   <td>
                     <div>
                       <div style="font-weight: 600; color: var(--color-brand-primary);">#{entry.entry_number}</div>
-                      <div class="{getBrewerNameClass()}" style="font-size: 0.875rem;">{getBeerNameDisplay(entry.beer_name)}</div>
+                      <div class="{getBrewerNameClass()}" style="font-size: var(--font-size-sm);">{getBeerNameDisplay(entry.beer_name)}</div>
                     </div>
                   </td>
                   <td><span class="{getBrewerNameClass()}">{getBrewerNameDisplay(entry.members?.name)}</span></td>
@@ -1270,7 +1315,7 @@
                   </td>
                   <td>
                     {#if entry.bjcp_categories}
-                      <span style="background: var(--color-gray-100); color: var(--color-gray-700); padding: 0.25rem 0.5rem; border-radius: var(--radius-sm); font-size: 0.875rem; font-weight: 600;">
+                      <span style="background: var(--color-gray-100); color: var(--color-gray-700); padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); font-size: var(--font-size-sm); font-weight: 600;">
                         {entry.bjcp_categories.category_number}{entry.bjcp_categories.subcategory_letter || ''}
                       </span>
                       {#if entry.bjcp_categories.subcategory_name}
@@ -1338,11 +1383,11 @@
                     <span class="mobile-detail-label">Style</span>
                     <span class="mobile-detail-value">
                       {#if entry.bjcp_categories}
-                        <span style="background: var(--color-gray-100); color: var(--color-gray-700); padding: 0.25rem 0.5rem; border-radius: var(--radius-sm); font-size: 0.875rem; font-weight: 600;">
+                        <span style="background: var(--color-gray-100); color: var(--color-gray-700); padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); font-size: var(--font-size-sm); font-weight: 600;">
                           {entry.bjcp_categories.category_number}{entry.bjcp_categories.subcategory_letter || ''}
                         </span>
                         {#if entry.bjcp_categories.subcategory_name}
-                          <br><small style="color: var(--color-text-secondary); font-size: 0.8rem;">{entry.bjcp_categories.subcategory_name}</small>
+                          <br><small class="category-sub">{entry.bjcp_categories.subcategory_name}</small>
                         {/if}
                       {:else}
                         -
@@ -1357,7 +1402,7 @@
                     <span class="mobile-detail-label">Score</span>
                     <span class="mobile-detail-value">
                       {#if scores.count > 0}
-                        <span style="background: {getScoreColor(scores.average)}; color: white; padding: 0.25rem 0.5rem; border-radius: var(--radius-sm); font-size: 0.875rem;">
+                        <span class="score-badge" style="background: {getScoreColor(scores.average)}">
                           {scores.average}/50
                         </span>
                       {:else}
@@ -1387,20 +1432,20 @@
             <!-- Custom Ranking Group Rankings -->
             {#each rankingGroups as group}
               {@const groupRankings = getGroupRankings(group.id)}
-              <div style="margin-bottom: 2rem;">
+              <div style="margin-bottom: var(--space-8);">
                 <h4>{group.group_name}</h4>
                 {#if group.group_description}
-                  <p style="color: var(--color-text-secondary); font-size: 0.875rem; margin-bottom: 1rem;">{group.group_description}</p>
+                  <p style="color: var(--color-text-secondary); font-size: var(--font-size-sm); margin-bottom: var(--space-4);">{group.group_description}</p>
                 {/if}
                 {#if groupRankings.length === 0}
                   <p style="color: var(--color-text-secondary); font-style: italic;">No rankings submitted yet</p>
                 {:else}
                   {#if groupRankings.length > 1 && hasMultipleJudges(groupRankings)}
-                    <div style="background: var(--color-success-bg); border: 1px solid var(--color-success); border-radius: var(--radius-md); padding: 1rem; margin-bottom: 1rem;">
-                      <div style="display: flex; align-items: center; gap: 0.5rem; font-weight: 600; color: var(--color-success-bg-strong);">
+                    <div class="success-panel">
+                      <div style="display: flex; align-items: center; gap: var(--space-2); font-weight: 600; color: var(--color-success-bg-strong);">
                         ✅ Multi-Judge Point Compilation
                       </div>
-                      <p style="color: var(--color-success-bg-strong); margin: 0.5rem 0 0; font-size: 0.875rem;">
+                      <p style="color: var(--color-success-bg-strong); margin: var(--space-2) 0 0; font-size: var(--font-size-sm);">
                         Rankings from {new Set(groupRankings.map(r => r.judge_id)).size} judges will be compiled using point system: 1st=3pts, 2nd=2pts, 3rd=1pt. Final placement determined by highest total points.
                       </p>
                     </div>
@@ -1424,18 +1469,18 @@
                           {@const placement = index + 1 === 1 ? '1st' : index + 1 === 2 ? '2nd' : index + 1 === 3 ? '3rd' : index + 1 <= 5 ? 'HM' : '-'}
                           <tr>
                             <td>
-                              <span style="font-size: 1.2rem; font-weight: 600;">
+                              <span class="score-value">
                                 {index + 1 === 1 ? '🥇' : index + 1 === 2 ? '🥈' : index + 1 === 3 ? '🥉' : `${index + 1}.`}
                               </span>
                             </td>
                             <td>
                               <div>
                                 <div style="font-weight: 600; color: var(--color-brand-primary);">#{entry.entry_number}</div>
-                                <div class="{getBrewerNameClass()}" style="font-size: 0.875rem;">{getBeerNameDisplay(entry.beer_name)}</div>
+                                <div class="{getBrewerNameClass()}" style="font-size: var(--font-size-sm);">{getBeerNameDisplay(entry.beer_name)}</div>
                               </div>
                             </td>
                             <td>
-                              <span style="font-weight: 700; font-size: 1.1rem; color: var(--color-success);">
+                              <span class="score-highlight">
                                 {entry.summary.totalPoints} {entry.summary.totalPoints === 1 ? 'pt' : 'pts'}
                               </span>
                             </td>
@@ -1470,14 +1515,14 @@
                           {@const entryPoints = getPointsForRanking(ranking.rank_position)}
                           <tr>
                             <td>
-                              <span style="font-size: 1.2rem; font-weight: 600;">
+                              <span class="score-value">
                                 {ranking.rank_position === 1 ? '🥇' : ranking.rank_position === 2 ? '🥈' : ranking.rank_position === 3 ? '🥉' : `${ranking.rank_position}.`}
                               </span>
                             </td>
                             <td>
                               <div>
                                 <div style="font-weight: 600; color: var(--color-brand-primary);">#{ranking.entry?.entry_number}</div>
-                                <div class="{getBrewerNameClass()}" style="font-size: 0.875rem;">{getBeerNameDisplay(ranking.entry?.beer_name)}</div>
+                                <div class="{getBrewerNameClass()}" style="font-size: var(--font-size-sm);">{getBeerNameDisplay(ranking.entry?.beer_name)}</div>
                               </div>
                             </td>
                             <td>
@@ -1499,17 +1544,17 @@
             <!-- Individual Category Rankings (default system) -->
             {#each categories as category}
               {@const categoryRankings = getCategoryRankings(category.id)}
-              <div style="margin-bottom: 2rem;">
+              <div style="margin-bottom: var(--space-8);">
                 <h4>{category.name}</h4>
                 {#if categoryRankings.length === 0}
                   <p style="color: var(--color-text-secondary); font-style: italic;">No rankings submitted yet</p>
                 {:else}
                   {#if categoryRankings.length > 1 && hasMultipleJudges(categoryRankings)}
-                    <div style="background: var(--color-success-bg); border: 1px solid var(--color-success); border-radius: var(--radius-md); padding: 1rem; margin-bottom: 1rem;">
-                      <div style="display: flex; align-items: center; gap: 0.5rem; font-weight: 600; color: var(--color-success-bg-strong);">
+                    <div class="success-panel">
+                      <div style="display: flex; align-items: center; gap: var(--space-2); font-weight: 600; color: var(--color-success-bg-strong);">
                         ✅ Multi-Judge Point Compilation
                       </div>
-                      <p style="color: var(--color-success-bg-strong); margin: 0.5rem 0 0; font-size: 0.875rem;">
+                      <p style="color: var(--color-success-bg-strong); margin: var(--space-2) 0 0; font-size: var(--font-size-sm);">
                         Rankings from {new Set(categoryRankings.map(r => r.judge_id)).size} judges will be compiled using point system: 1st=3pts, 2nd=2pts, 3rd=1pt. Final placement determined by highest total points.
                       </p>
                     </div>
@@ -1533,18 +1578,18 @@
                           {@const placement = index + 1 === 1 ? '1st' : index + 1 === 2 ? '2nd' : index + 1 === 3 ? '3rd' : index + 1 <= 5 ? 'HM' : '-'}
                           <tr>
                             <td>
-                              <span style="font-size: 1.2rem; font-weight: 600;">
+                              <span class="score-value">
                                 {index + 1 === 1 ? '🥇' : index + 1 === 2 ? '🥈' : index + 1 === 3 ? '🥉' : `${index + 1}.`}
                               </span>
                             </td>
                             <td>
                               <div>
                                 <div style="font-weight: 600; color: var(--color-brand-primary);">#{entry.entry_number}</div>
-                                <div class="{getBrewerNameClass()}" style="font-size: 0.875rem;">{getBeerNameDisplay(entry.beer_name)}</div>
+                                <div class="{getBrewerNameClass()}" style="font-size: var(--font-size-sm);">{getBeerNameDisplay(entry.beer_name)}</div>
                               </div>
                             </td>
                             <td>
-                              <span style="font-weight: 700; font-size: 1.1rem; color: var(--color-success);">
+                              <span class="score-highlight">
                                 {entry.summary.totalPoints} {entry.summary.totalPoints === 1 ? 'pt' : 'pts'}
                               </span>
                             </td>
@@ -1579,14 +1624,14 @@
                           {@const entryPoints = getPointsForRanking(ranking.rank_position)}
                           <tr>
                             <td>
-                              <span style="font-size: 1.2rem; font-weight: 600;">
+                              <span class="score-value">
                                 {ranking.rank_position === 1 ? '🥇' : ranking.rank_position === 2 ? '🥈' : ranking.rank_position === 3 ? '🥉' : `${ranking.rank_position}.`}
                               </span>
                             </td>
                             <td>
                               <div>
                                 <div style="font-weight: 600; color: var(--color-brand-primary);">#{ranking.entry?.entry_number}</div>
-                                <div class="{getBrewerNameClass()}" style="font-size: 0.875rem;">{getBeerNameDisplay(ranking.entry?.beer_name)}</div>
+                                <div class="{getBrewerNameClass()}" style="font-size: var(--font-size-sm);">{getBeerNameDisplay(ranking.entry?.beer_name)}</div>
                               </div>
                             </td>
                             <td>
@@ -1626,17 +1671,17 @@
                   </div>
 
                   {#if groupRankings.length === 0}
-                    <div style="padding: 1rem; text-align: center; color: var(--color-text-secondary); font-style: italic;">
+                    <div style="padding: var(--space-4); text-align: center; color: var(--color-text-secondary); font-style: italic;">
                       No rankings submitted yet
                     </div>
                   {:else}
                     {#if groupRankings.length > 1 && hasMultipleJudges(groupRankings)}
-                      <div style="background: var(--color-success-bg); border: 1px solid var(--color-success); border-radius: var(--radius-md); padding: 1rem; margin-bottom: 1rem; font-size: 0.875rem; color: var(--color-success-bg-strong);">
+                      <div class="success-panel is-note">
                         ✅ Multi-Judge Point Compilation - {new Set(groupRankings.map(r => r.judge_id)).size} judges
                       </div>
                     {/if}
 
-                    <div style="margin-top: 1rem;">
+                    <div style="margin-top: var(--space-4);">
                       {#if hasMultipleJudges(groupRankings)}
                         {#each getUniqueEntriesFromRankings(groupRankings)
                           .map(entry => ({ ...entry, summary: getEntryPointsSummary(entry.id, entry.bjcp_category_id, group.id) }))
@@ -1649,7 +1694,7 @@
                             <div class="mobile-ranking-entry">
                               <div class="mobile-ranking-entry-number">#{entry.entry_number}</div>
                               <div class="mobile-ranking-beer-name {getBrewerNameClass()}">{getBeerNameDisplay(entry.beer_name)}</div>
-                              <div style="font-size: 0.8rem; color: var(--color-text-secondary); margin-top: 0.25rem;">
+                              <div class="score-sublabel">
                                 {entry.summary.judgeCount} judge{entry.summary.judgeCount === 1 ? '' : 's'} • {placement}
                               </div>
                             </div>
@@ -1668,7 +1713,7 @@
                             <div class="mobile-ranking-entry">
                               <div class="mobile-ranking-entry-number">#{ranking.entry?.entry_number}</div>
                               <div class="mobile-ranking-beer-name {getBrewerNameClass()}">{getBeerNameDisplay(ranking.entry?.beer_name)}</div>
-                              <div style="font-size: 0.8rem; color: var(--color-text-secondary); margin-top: 0.25rem;">
+                              <div class="score-sublabel">
                                 {ranking.judge?.name}{#if ranking.ranking_notes} • {ranking.ranking_notes}{/if}
                               </div>
                             </div>
@@ -1697,17 +1742,17 @@
                   </div>
 
                   {#if categoryRankings.length === 0}
-                    <div style="padding: 1rem; text-align: center; color: var(--color-text-secondary); font-style: italic;">
+                    <div style="padding: var(--space-4); text-align: center; color: var(--color-text-secondary); font-style: italic;">
                       No rankings submitted yet
                     </div>
                   {:else}
                     {#if categoryRankings.length > 1 && hasMultipleJudges(categoryRankings)}
-                      <div style="background: var(--color-success-bg); border: 1px solid var(--color-success); border-radius: var(--radius-md); padding: 1rem; margin-bottom: 1rem; font-size: 0.875rem; color: var(--color-success-bg-strong);">
+                      <div class="success-panel is-note">
                         ✅ Multi-Judge Point Compilation - {new Set(categoryRankings.map(r => r.judge_id)).size} judges
                       </div>
                     {/if}
 
-                    <div style="margin-top: 1rem;">
+                    <div style="margin-top: var(--space-4);">
                       {#if hasMultipleJudges(categoryRankings)}
                         {#each getUniqueEntriesFromRankings(categoryRankings)
                           .map(entry => ({ ...entry, summary: getEntryPointsSummary(entry.id, category.id, null) }))
@@ -1720,7 +1765,7 @@
                             <div class="mobile-ranking-entry">
                               <div class="mobile-ranking-entry-number">#{entry.entry_number}</div>
                               <div class="mobile-ranking-beer-name {getBrewerNameClass()}">{getBeerNameDisplay(entry.beer_name)}</div>
-                              <div style="font-size: 0.8rem; color: var(--color-text-secondary); margin-top: 0.25rem;">
+                              <div class="score-sublabel">
                                 {entry.summary.judgeCount} judge{entry.summary.judgeCount === 1 ? '' : 's'} • {placement}
                               </div>
                             </div>
@@ -1739,7 +1784,7 @@
                             <div class="mobile-ranking-entry">
                               <div class="mobile-ranking-entry-number">#{ranking.entry?.entry_number}</div>
                               <div class="mobile-ranking-beer-name {getBrewerNameClass()}">{getBeerNameDisplay(ranking.entry?.beer_name)}</div>
-                              <div style="font-size: 0.8rem; color: var(--color-text-secondary); margin-top: 0.25rem;">
+                              <div class="score-sublabel">
                                 {ranking.judge?.name}{#if ranking.ranking_notes} • {ranking.ranking_notes}{/if}
                               </div>
                             </div>

--- a/src/routes/officers/manage-competitions/results/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/results/[id]/+page.svelte
@@ -770,6 +770,11 @@
     margin-top: var(--space-4);
     width: 100%;
   }
+
+  .btn-compact {
+    padding: 0.4rem 0.8rem;
+    font-size: 0.85rem;
+  }
 </style>
 
 <Hero
@@ -923,9 +928,8 @@
                   {/if}
                 </td>
                 <td>
-                  <button 
-                    class="btn btn-primary" 
-                    style="padding: 0.4rem 0.8rem; font-size: 0.85rem;"
+                  <button
+                    class="btn btn-primary btn-compact"
                     on:click={() => saveEntryResults(entry.id)}
                     disabled={isSaving}
                   >
@@ -951,17 +955,17 @@
                 {/if}
               </span>
             </div>
-            <div style="margin-bottom: 1rem;">
+            <div style="margin-bottom: var(--space-4);">
               <div class="{getBrewerNameClass()}"><strong>{getBrewerNameDisplay(entry.member_name)}</strong></div>
               <div class="{getBrewerNameClass()}">{getBeerNameDisplay(entry.beer_name)}</div>
               <span class="category-badge">{entry.category_display}</span>
-              <div style="margin-top: 0.5rem;">
-                <span style="font-size: 0.875rem; color: var(--color-text-secondary);">Ranking Points: </span>
+              <div style="margin-top: var(--space-2);">
+                <span style="font-size: var(--font-size-sm); color: var(--color-text-secondary);">Ranking Points: </span>
                 <span style="font-weight: 600; color: {entry.ranking_points > 0 ? 'var(--color-success)' : 'var(--color-text-secondary)'};">
                   {entry.ranking_points} {entry.ranking_points === 1 ? 'pt' : 'pts'}
                 </span>
                 {#if entry.judge_count > 0}
-                  <span style="font-size: 0.875rem; color: var(--color-text-secondary);"> ({entry.judge_count} judge{entry.judge_count === 1 ? '' : 's'})</span>
+                  <span style="font-size: var(--font-size-sm); color: var(--color-text-secondary);"> ({entry.judge_count} judge{entry.judge_count === 1 ? '' : 's'})</span>
                 {/if}
               </div>
             </div>

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -201,7 +201,7 @@
       <!-- Editable Fields -->
       <Card class="form-section">
         <h3>
-          <Edit size={20} strokeWidth={2} style="display: inline-block; vertical-align: text-bottom; margin-right: 0.5rem;" />
+          <Edit size={20} strokeWidth={2} class="icon-inline-lg" />
           Edit Information
         </h3>
         <div class="form-grid">
@@ -280,10 +280,10 @@
             <span class="info-label">Account Status</span>
             <span class="info-value status-active">
               {#if profile.active}
-                <Check size={16} strokeWidth={2} style="display: inline-block; vertical-align: text-bottom; margin-right: 0.25rem; color: var(--color-success);" />
+                <Check size={16} strokeWidth={2} class="icon-inline" style="color: var(--color-success);" />
                 Active
               {:else}
-                <X size={16} strokeWidth={2} style="display: inline-block; vertical-align: text-bottom; margin-right: 0.25rem; color: var(--color-danger);" />
+                <X size={16} strokeWidth={2} class="icon-inline" style="color: var(--color-danger);" />
                 Inactive
               {/if}
             </span>


### PR DESCRIPTION
## Summary
Migrates hard-coded inline `style="..."` attributes across competition, judging, and profile routes to the design system, and adds a CI guard so new ones can't creep back in. Closes #64.

## Changes
- **Tokenized inline styles** across 13 route files — raw px/rem/hex → `var(--space-*)`, `var(--font-size-*)`, `var(--color-*)`.
- **Scoped `<style>` classes** for repeated one-off styling (`.section-hint`, `.btn-compact`, `.empty-hint`, `.category-sub`, etc.) — now covered by stylelint instead of bypassing it.
- **Shared utility classes** added to `src/app.css` (`.icon-inline-after`, `.icon-inline-lg`, `.icon-spin` + `@keyframes spin`) plus two new tokens (`--color-info-bg-subtle`, `--color-accent-indigo`).
- **Guard script** `scripts/check-inline-styles.js` (`npm run lint:inline`) — flags any new inline `style=` with hard-coded hex/px/rem while permitting token-only and dynamic custom-property inline styles.
- **CI** `.github/workflows/lint.yml` — runs the guard on every PR and on pushes to master/develop. Zero-dependency script, so the job is just checkout + Node 18.

Inline `style=` count in `src/` dropped from **122 → 86**; the remaining 86 are token-only or dynamic (guard-approved).

## Verification
- `npm run lint:inline` → ✓ no hard-coded inline styles
- `npm run check` → 0 errors
- `npx stylelint` on modified files → no new errors (one pre-existing empty-`@media` block untouched)

## Notes
- Only the inline-style guard is wired into CI. `lint:css` is intentionally not added yet — stylelint currently has pre-existing `✖` errors on unrelated code that would make CI red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)