### PR TITLE
feat(officers): shared layout guard + fix profile-load flash (#56, #59, #63, #66)

### DIFF
--- a/src/routes/officers/+layout.svelte
+++ b/src/routes/officers/+layout.svelte
@@ -1,0 +1,74 @@
+<script>
+  import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
+  import { goto } from '$app/navigation';
+  import { supabase } from '$lib/supabaseClient';
+  import { user } from '$lib/stores/user';
+  import { userProfile } from '$lib/stores/userProfile';
+  import { Container, LoadingSpinner, EmptyState, Button } from '$lib/components/ui';
+
+  /**
+   * Single access-control point for every /officers/* route (issues #59, #63).
+   *
+   * `authState` keeps "loading" distinct from "denied" so protected content is
+   * never rendered before the profile resolves — the slot below is only mounted
+   * once the user is confirmed to be an officer, which closes the flash-of-
+   * officer-UI race from #63.
+   */
+  let authState = 'loading'; // 'loading' | 'denied' | 'authorized'
+
+  onMount(async () => {
+    try {
+      const {
+        data: { user: authUser }
+      } = await supabase.auth.getUser();
+      user.set(authUser);
+
+      if (!authUser) {
+        goto('/login');
+        return;
+      }
+
+      // Reuse a profile the root layout already loaded for this user; otherwise
+      // fetch it directly so the gate never keys on a still-loading null.
+      let profile = get(userProfile);
+      if (!profile || profile.id !== authUser.id) {
+        const { data, error } = await supabase
+          .from('members')
+          .select('*')
+          .eq('id', authUser.id)
+          .single();
+        profile = error ? null : data;
+        userProfile.set(profile);
+      }
+
+      authState = profile?.is_officer ? 'authorized' : 'denied';
+    } catch (err) {
+      console.error('Officer access check failed:', err);
+      authState = 'denied';
+    }
+  });
+
+  // Re-gate if the session drops after the initial check (e.g. sign-out).
+  $: if (authState !== 'loading' && !$user) {
+    goto('/login');
+  }
+</script>
+
+{#if authState === 'loading' || !$user}
+  <Container size="lg">
+    <LoadingSpinner message="Verifying permissions..." />
+  </Container>
+{:else if authState === 'denied'}
+  <Container size="lg">
+    <EmptyState
+      icon="🔒"
+      title="Access Restricted"
+      description="You are not authorized to view this page. Officer privileges are required."
+    >
+      <Button variant="primary" on:click={() => goto('/')}>Return Home</Button>
+    </EmptyState>
+  </Container>
+{:else}
+  <slot />
+{/if}

--- a/src/routes/officers/+layout.svelte
+++ b/src/routes/officers/+layout.svelte
@@ -14,10 +14,16 @@
    * never rendered before the profile resolves — the slot below is only mounted
    * once the user is confirmed to be an officer, which closes the flash-of-
    * officer-UI race from #63.
+   *
+   * A profile fetch that *fails* (network blip, transient Supabase error) is a
+   * distinct "error" state, not "denied": a real officer must never be shown a
+   * hard access-denied over a transient failure. Every non-authorized state
+   * still withholds the slot, so the fail-closed guarantee is preserved.
    */
-  let authState = 'loading'; // 'loading' | 'denied' | 'authorized'
+  let authState = 'loading'; // 'loading' | 'error' | 'denied' | 'authorized'
 
-  onMount(async () => {
+  async function checkAccess() {
+    authState = 'loading';
     try {
       const {
         data: { user: authUser }
@@ -38,24 +44,44 @@
           .select('*')
           .eq('id', authUser.id)
           .single();
-        profile = error ? null : data;
+
+        // Couldn't verify — don't deny a possibly-legitimate officer; let them retry.
+        if (error) {
+          authState = 'error';
+          return;
+        }
+
+        profile = data;
         userProfile.set(profile);
       }
 
       authState = profile?.is_officer ? 'authorized' : 'denied';
     } catch (err) {
       console.error('Officer access check failed:', err);
-      authState = 'denied';
+      authState = 'error';
     }
-  });
+  }
 
-  // Re-gate if the session drops after the initial check (e.g. sign-out).
-  $: if (authState !== 'loading' && !$user) {
+  onMount(checkAccess);
+
+  // Re-gate if the session drops after a settled check (e.g. sign-out). The
+  // "error" state is left alone so a transient failure can't force a redirect.
+  $: if ((authState === 'authorized' || authState === 'denied') && !$user) {
     goto('/login');
   }
 </script>
 
-{#if authState === 'loading' || !$user}
+{#if authState === 'error'}
+  <Container size="lg">
+    <EmptyState
+      icon="⚠️"
+      title="Couldn't verify access"
+      description="We couldn't confirm your permissions just now. Please try again."
+    >
+      <Button variant="primary" on:click={checkAccess}>Retry</Button>
+    </EmptyState>
+  </Container>
+{:else if authState === 'loading' || !$user}
   <Container size="lg">
     <LoadingSpinner message="Verifying permissions..." />
   </Container>

--- a/src/routes/officers/+page.svelte
+++ b/src/routes/officers/+page.svelte
@@ -1,15 +1,11 @@
 <script>
-  import { user } from '$lib/stores/user';
   import { userProfile } from '$lib/stores/userProfile';
   import { supabase } from '$lib/supabaseClient';
-  import { goto } from '$app/navigation';
   import { onMount } from 'svelte';
   import { competitionManagementStore } from '$lib/stores/competitionManagementStore';
-  import { Hero, Container, LoadingSpinner, EmptyState, Badge, Card, ActionCard } from '$lib/components/ui';
+  import { Hero, Container, Badge, Card, ActionCard } from '$lib/components/ui';
   import { FileCheck, List, Trophy, Users, BarChart, ClipboardList, UserCheck, TrendingUp, Bell, Calendar } from 'lucide-svelte';
 
-  let isLoading = true;
-  let accessDenied = false;
   let statsLoading = true;
 
   // Stats data
@@ -19,26 +15,10 @@
   let activeCompetitions = 0;
   let totalCompetitionEntries = 0;
 
-  $: if ($user !== undefined && $userProfile !== undefined) {
-    isLoading = false;
-
-    if (!$user) {
-      goto('/login');
-    } else if ($userProfile && !$userProfile.is_officer) {
-      accessDenied = true;
-    } else if ($userProfile && $userProfile.is_officer) {
-      accessDenied = false;
-      loadDashboardStats();
-      competitionManagementStore.initialize();
-    }
-  }
-
   onMount(() => {
-    if (typeof window !== 'undefined') {
-      if ($userProfile?.is_officer) {
-        loadDashboardStats();
-      }
-    }
+    // The officers/+layout guard guarantees an officer reaches this page.
+    loadDashboardStats();
+    competitionManagementStore.initialize();
   });
 
   $: if ($competitionManagementStore.stats) {
@@ -97,30 +77,7 @@
   <title>Officer Tools | JAX Members Portal</title>
 </svelte:head>
 
-{#if isLoading}
-  <Container size="lg">
-    <LoadingSpinner message="Verifying permissions..." />
-  </Container>
-{:else if !$user}
-  <Container size="lg">
-    <EmptyState
-      title="Authentication Required"
-      message="Please log in to access officer tools."
-      actionLabel="Sign In"
-      actionHref="/login"
-    />
-  </Container>
-{:else if accessDenied}
-  <Container size="lg">
-    <EmptyState
-      title="Access Restricted"
-      message="You are not authorized to view this page. Officer privileges are required."
-      actionLabel="Return Home"
-      actionHref="/"
-    />
-  </Container>
-{:else}
-  <Hero
+<Hero
     title="Officer Dashboard"
     subtitle="Administrative Tools & Club Management"
     backgroundImage="/Jax-Banner.png"
@@ -287,7 +244,6 @@
       </div>
     </section>
   </Container>
-{/if}
 
 <style>
   .welcome-card {

--- a/src/routes/officers/approvals/+page.svelte
+++ b/src/routes/officers/approvals/+page.svelte
@@ -2,15 +2,12 @@
   import { supabase } from "$lib/supabaseClient";
   import { onMount, onDestroy } from "svelte";
   import toast from "svelte-french-toast";
-  import { user } from "$lib/stores/user";
-  import { userProfile } from "$lib/stores/userProfile";
   import {
     approvals as storeApprovals,
     message as storeMessage,
     loadApprovals,
     loading,
   } from "$lib/stores/approvalsStore.js";
-  import { page } from "$app/stores";
   import { formatDate, formatSubmissionTime } from "$lib/utils/dateUtils.js";
   import { Hero, Container, LoadingSpinner, EmptyState, Button } from '$lib/components/ui';
   import { CheckCircle, X, Lock, AlertTriangle, PartyPopper, RefreshCw, ClipboardList } from 'lucide-svelte';
@@ -33,14 +30,6 @@
     return () => {
       // No cleanup needed now
     };
-  }
-
-  // Check if user is authorized
-  $: isAuthorized = $user && $userProfile?.is_officer;
-
-  // Load data when authorized
-  $: if (isAuthorized) {
-    loadApprovals(true);
   }
 
   // Format date helper
@@ -156,21 +145,14 @@
     const cleanup = setupEventHandlers();
     cleanupFunctions.push(cleanup);
 
-    // Initial load if authorized
-    if (isAuthorized) {
-      loadApprovals(true);
-    }
+    // Access control is enforced by officers/+layout; officers only reach here.
+    loadApprovals(true);
   });
 
   onDestroy(() => {
     // Cleanup all event listeners
     cleanupFunctions.forEach((cleanup) => cleanup());
   });
-
-  // Reload when navigating to approvals page
-  $: if ($page.url.pathname === "/officers/approvals" && isAuthorized) {
-    loadApprovals(true);
-  }
 </script>
 
 <Hero
@@ -185,22 +167,6 @@
 
   {#if $loading}
     <LoadingSpinner message="Loading submissions..." />
-  {:else if !$user}
-    <EmptyState
-      icon="🔒"
-      title="Authentication Required"
-      message="Please log in to access the approvals system."
-      actionLabel="Sign In"
-      actionHref="/login"
-    />
-  {:else if !$userProfile?.is_officer}
-    <EmptyState
-      icon="⚠️"
-      title="Access Restricted"
-      message="Officer privileges are required to review submissions."
-      actionLabel="Back to Officer Tools"
-      actionHref="/officers"
-    />
   {:else if submissions.length > 0}
     <div class="submissions-container">
       <!-- Summary Stats -->

--- a/src/routes/officers/manage-competitions/+page.svelte
+++ b/src/routes/officers/manage-competitions/+page.svelte
@@ -2,7 +2,6 @@
 <script>
   import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
-  import { userProfile } from '$lib/stores/userProfile';
   import { competitionManagementStore, competitions, isLoading, error, stats } from '$lib/stores/competitionManagementStore';
   import Hero from "$lib/components/ui/Hero.svelte";
   import Container from "$lib/components/ui/Container.svelte";
@@ -14,10 +13,6 @@
   import toast from 'svelte-french-toast';
   import { showConfirm } from '$lib/stores/confirmDialog.js';
   
-  // Check officer status
-  $: if ($userProfile && !$userProfile.is_officer) {
-    goto('/');
-  }
 
   let searchQuery = '';
   let filterStatus = 'all'; // all, active, upcoming, past
@@ -286,7 +281,6 @@
     background: white;
   }
 
-
   .competitions-table {
     background: white;
     border-radius: var(--radius-md);
@@ -434,7 +428,6 @@
   .btn-delete:hover {
     background: var(--color-danger-hover);
   }
-
 
   .error {
     background: var(--color-danger-bg-soft);

--- a/src/routes/officers/manage-competitions/create/+page.svelte
+++ b/src/routes/officers/manage-competitions/create/+page.svelte
@@ -2,7 +2,6 @@
 <script>
   import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
-  import { userProfile } from '$lib/stores/userProfile';
   import { competitionManagementStore } from '$lib/stores/competitionManagementStore';
   import { bjcpCategories, categoriesByNumber, loadBjcpCategories } from '$lib/stores/bjcpCategoryStore';
   import CategorySelector from '$lib/components/CategorySelector.svelte';
@@ -13,10 +12,6 @@
   import toast from 'svelte-french-toast';
   import { showConfirm } from '$lib/stores/confirmDialog.js';
   
-  // Check officer status
-  $: if ($userProfile && !$userProfile.is_officer) {
-    goto('/');
-  }
 
   // Form fields
   let name = '';
@@ -275,7 +270,6 @@
     padding-top: 2rem;
     border-top: 1px solid var(--color-gray-150);
   }
-
 
   .section-title {
     font-size: 1.25rem;

--- a/src/routes/officers/manage-competitions/edit/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/edit/[id]/+page.svelte
@@ -3,7 +3,6 @@
   import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
-  import { userProfile } from '$lib/stores/userProfile';
   import { competitionManagementStore, updateCompetition } from '$lib/stores/competitionManagementStore';
   import { bjcpCategories, categoriesByNumber, loadBjcpCategories } from '$lib/stores/bjcpCategoryStore';
   import CategorySelector from '$lib/components/CategorySelector.svelte';
@@ -16,10 +15,6 @@
   import toast from 'svelte-french-toast';
   import { showConfirm } from '$lib/stores/confirmDialog.js';
   
-  // Check officer status
-  $: if ($userProfile && !$userProfile.is_officer) {
-    goto('/');
-  }
 
   // Get competition ID from URL
   $: competitionId = $page.params.id;
@@ -432,7 +427,6 @@
     padding-top: 2rem;
     border-top: 1px solid var(--color-gray-150);
   }
-
 
   .section-title {
     font-size: 1.25rem;

--- a/src/routes/officers/manage-competitions/entries/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/entries/[id]/+page.svelte
@@ -18,7 +18,10 @@
   let showAccessDeniedModal = false;
   let isAuthorized = false;
 
-  // Check Competition Director status - only Comp Directors can access entries
+  // Access control is layered:
+  //   1. officers/+layout enforces the is_officer baseline for every /officers route.
+  //   2. Entry management is intentionally restricted further to Competition
+  //      Directors only, so non-CD officers get the in-page access-denied modal below.
   $: if ($userProfile) {
     if ($userProfile.role === 'competition_director') {
       isAuthorized = true;

--- a/src/routes/officers/manage-competitions/judges/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/judges/[id]/+page.svelte
@@ -22,11 +22,6 @@
   import toast from 'svelte-french-toast';
   import { showConfirm } from '$lib/stores/confirmDialog.js';
 
-  // Check officer status
-  $: if ($userProfile && !$userProfile.is_officer) {
-    goto('/');
-  }
-
   // Get competition ID from URL
   $: competitionId = $page.params.id;
 

--- a/src/routes/officers/manage-competitions/judging-dashboard/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/judging-dashboard/[id]/+page.svelte
@@ -14,11 +14,6 @@
   import toast from 'svelte-french-toast';
   import { showConfirm } from '$lib/stores/confirmDialog.js';
 
-  // Check officer status
-  $: if ($userProfile && !$userProfile.is_officer) {
-    goto('/');
-  }
-
   // Get competition ID from URL
   $: competitionId = $page.params.id;
 
@@ -664,7 +659,6 @@
   .btn-secondary:hover:not(:disabled) {
     background: var(--color-gray-600);
   }
-
 
   /* Content Sections */
   .content-section {

--- a/src/routes/officers/manage-competitions/results/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/results/[id]/+page.svelte
@@ -13,10 +13,6 @@
   import toast from 'svelte-french-toast';
   import { showConfirm } from '$lib/stores/confirmDialog.js';
   
-  // Check officer status
-  $: if ($userProfile && !$userProfile.is_officer) {
-    goto('/');
-  }
 
   // Get competition ID from URL
   $: competitionId = $page.params.id;
@@ -594,7 +590,6 @@
     min-width: 150px;
   }
 
-
   .results-table {
     background: white;
     border-radius: var(--radius-md);
@@ -681,7 +676,6 @@
     font-size: 0.75rem;
     margin-left: 0.5rem;
   }
-
 
   /* Entry cards for mobile */
   .entry-cards {

--- a/src/routes/officers/manage-events/+page.svelte
+++ b/src/routes/officers/manage-events/+page.svelte
@@ -1,7 +1,6 @@
 <script>
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { userProfile } from '$lib/stores/userProfile.js';
   import {
     events,
     isLoading,
@@ -35,10 +34,6 @@
   } from 'lucide-svelte';
   import toast from 'svelte-french-toast';
   import { showConfirm } from '$lib/stores/confirmDialog.js';
-
-  $: if ($userProfile && !$userProfile.is_officer) {
-    goto('/');
-  }
 
   let filterStatus = 'all';
   let searchQuery = '';

--- a/src/routes/officers/manage-events/create/+page.svelte
+++ b/src/routes/officers/manage-events/create/+page.svelte
@@ -1,14 +1,9 @@
 <script>
   import { goto } from '$app/navigation';
-  import { userProfile } from '$lib/stores/userProfile.js';
   import { createEvent } from '$lib/stores/eventManagementStore.js';
   import { Hero, Container, Card } from '$lib/components/ui';
   import EventForm from '$lib/components/EventForm.svelte';
   import toast from 'svelte-french-toast';
-
-  $: if ($userProfile && !$userProfile.is_officer) {
-    goto('/');
-  }
 
   let isSubmitting = false;
 

--- a/src/routes/officers/manage-events/edit/[id]/+page.svelte
+++ b/src/routes/officers/manage-events/edit/[id]/+page.svelte
@@ -2,7 +2,6 @@
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
-  import { userProfile } from '$lib/stores/userProfile.js';
   import { loadEvent, updateEvent } from '$lib/stores/eventManagementStore.js';
   import {
     Hero,
@@ -15,10 +14,6 @@
   import EventForm from '$lib/components/EventForm.svelte';
   import toast from 'svelte-french-toast';
   import { ArrowLeft, Printer } from 'lucide-svelte';
-
-  $: if ($userProfile && !$userProfile.is_officer) {
-    goto('/');
-  }
 
   $: eventId = $page.params.id;
 

--- a/src/routes/officers/manage-events/signups/[id]/+page.svelte
+++ b/src/routes/officers/manage-events/signups/[id]/+page.svelte
@@ -2,7 +2,6 @@
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
-  import { userProfile } from '$lib/stores/userProfile.js';
   import {
     loadEvent,
     loadEventSignups,
@@ -24,10 +23,6 @@
   import { ArrowLeft, Printer, Pencil, UserPlus, Trash2 } from 'lucide-svelte';
   import toast from 'svelte-french-toast';
   import { showConfirm } from '$lib/stores/confirmDialog.js';
-
-  $: if ($userProfile && !$userProfile.is_officer) {
-    goto('/');
-  }
 
   $: eventId = $page.params.id;
 

--- a/src/routes/officers/members/+page.svelte
+++ b/src/routes/officers/members/+page.svelte
@@ -1,7 +1,6 @@
 <!-- src/routes/officer-tools/manage-members/+page.svelte -->
 <script>
   import { onMount, onDestroy } from 'svelte';
-  import { goto } from '$app/navigation';
   import { userProfile } from '$lib/stores/userProfile';
   import memberManagementStore, {
     members,
@@ -63,7 +62,6 @@
   }
 
   // Reactive variables for UI state
-  $: isOfficer = $userProfile?.is_officer || false;
   $: hasManagePermissions = $canManageOfficers;
 
   // Filter role options based on current user permissions
@@ -246,12 +244,8 @@
   // Lifecycle
   onMount(async () => {
     unsubscribeVisibility = setupEventHandlers();
-    
-    if (!isOfficer) {
-      goto('/');
-      return;
-    }
 
+    // Access control is enforced by officers/+layout; officers only reach here.
     await memberManagementStore.loadMembers();
   });
 
@@ -266,16 +260,7 @@
   import { showConfirm } from '$lib/stores/confirmDialog.js';
 </script>
 
-{#if !isOfficer}
-  <Container size="xl">
-    <EmptyState
-      icon="🔒"
-      title="Access Denied"
-      message="You need officer privileges to access this page."
-    />
-  </Container>
-{:else}
-  <Hero
+<Hero
     title="Manage Members"
     subtitle="View and manage club members, their roles, activity, and point standings"
     backgroundImage="/Jax-Banner.png"
@@ -523,7 +508,6 @@
       {/if}
     {/if}
   </Container>
-{/if}
 
 <!-- Member Details Modal -->
 {#if showMemberModal && selectedMember}

--- a/src/routes/officers/notifications/+page.svelte
+++ b/src/routes/officers/notifications/+page.svelte
@@ -1,10 +1,9 @@
 <script>
-  import { user } from '$lib/stores/user';
-  import { userProfile } from '$lib/stores/userProfile';
   import { supabase } from '$lib/supabaseClient';
   import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
   import toast from 'svelte-french-toast';
-  import { Hero, Container, Card, Button, LoadingSpinner, EmptyState } from '$lib/components/ui';
+  import { Hero, Container, Card, Button } from '$lib/components/ui';
   import { Bell } from 'lucide-svelte';
 
   let title = '';
@@ -13,11 +12,8 @@
   let subscriberCount = null;
   let lastResult = null;
 
-  $: if ($user !== undefined && $userProfile !== undefined) {
-    if (!$user) goto('/login');
-    else if ($userProfile && !$userProfile.is_officer) goto('/');
-    else if ($userProfile?.is_officer) loadSubscriberCount();
-  }
+  // Access control is enforced by officers/+layout; officers only reach here.
+  onMount(loadSubscriberCount);
 
   async function loadSubscriberCount() {
     try {
@@ -84,21 +80,7 @@
   <title>Send Notification | JAX Members Portal</title>
 </svelte:head>
 
-{#if $user === undefined || $userProfile === undefined}
-  <Container size="lg">
-    <LoadingSpinner message="Verifying permissions..." />
-  </Container>
-{:else if !$userProfile?.is_officer}
-  <Container size="lg">
-    <EmptyState
-      title="Access Restricted"
-      message="Officer privileges required."
-      actionLabel="Return Home"
-      actionHref="/"
-    />
-  </Container>
-{:else}
-  <Hero
+<Hero
     title="Send Notification"
     subtitle="Push a message to all subscribed members"
     backgroundImage="/Jax-Banner.png"
@@ -185,7 +167,6 @@
       </form>
     </Card>
   </Container>
-{/if}
 
 <style>
   .page-header {

--- a/src/routes/officers/reports/+page.svelte
+++ b/src/routes/officers/reports/+page.svelte
@@ -1,30 +1,9 @@
 <script>
   import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
-  import { onMount } from 'svelte';
   import { Hero, Container, Button } from '$lib/components/ui';
 
-  let pageTitle = 'Coming Soon';
-  let featureName = 'This Feature';
-
-  // Determine feature name based on current route
-  onMount(() => {
-    const pathname = $page.url.pathname;
-    
-    if (pathname.includes('/officers/members')) {
-      pageTitle = 'Member Management';
-      featureName = 'Member Management Tools';
-    } else if (pathname.includes('/officers/reports')) {
-      pageTitle = 'Reports Dashboard';
-      featureName = 'Reports & Analytics';
-    } else if (pathname.includes('/officers/')) {
-      // Generic officer tool
-      const segments = pathname.split('/');
-      const toolName = segments[segments.length - 1];
-      pageTitle = toolName.charAt(0).toUpperCase() + toolName.slice(1);
-      featureName = `${pageTitle} Tools`;
-    }
-  });
+  // Static placeholder until the Reports & Analytics feature is built.
+  const featureName = 'Reports & Analytics';
 
   function goBackToOfficers() {
     goto('/officers');
@@ -44,7 +23,7 @@
     <div class="construction-icon">🚧</div>
 
     <div class="hero-section">
-      <h1>{pageTitle}</h1>
+      <h1>Reports Dashboard</h1>
       <p class="subtitle">Coming Soon</p>
     </div>
 
@@ -60,22 +39,10 @@
         <div class="features-preview">
           <h3>What's Coming:</h3>
           <ul class="features-list">
-            {#if pageTitle === 'Member Management'}
-              <li>👤 View and edit member profiles</li>
-              <li>🔧 Manage officer permissions</li>
-              <li>📊 Member activity tracking</li>
-              <li>📧 Bulk communication tools</li>
-            {:else if pageTitle === 'Reports Dashboard'}
-              <li>📈 Monthly activity reports</li>
-              <li>🏆 Points distribution analytics</li>
-              <li>📋 Submission trend analysis</li>
-              <li>📊 Member engagement metrics</li>
-            {:else}
-              <li>⚡ Powerful administrative tools</li>
-              <li>📊 Advanced analytics</li>
-              <li>🔧 Enhanced management features</li>
-              <li>📈 Real-time reporting</li>
-            {/if}
+            <li>📈 Monthly activity reports</li>
+            <li>🏆 Points distribution analytics</li>
+            <li>📋 Submission trend analysis</li>
+            <li>📊 Member engagement metrics</li>
           </ul>
         </div>
 

--- a/src/routes/officers/view-all/+page.svelte
+++ b/src/routes/officers/view-all/+page.svelte
@@ -1,16 +1,13 @@
 <script>
   import { onMount, onDestroy } from "svelte";
-  import { user } from "$lib/stores/user";
-  import { userProfile } from "$lib/stores/userProfile";
   import {
     allSubmissions as storeAll,
     loadAllSubmissions,
     loading,
   } from "$lib/stores/viewAllStore.js";
-  import { page } from "$app/stores";
   import { formatDate, formatSubmissionTime } from "$lib/utils/dateUtils.js";
   import { Hero, Container, LoadingSpinner, EmptyState, Button } from '$lib/components/ui';
-  import { Lock, AlertTriangle, Search, CheckCircle2, Clock, X, Trash2, ClipboardList, Filter } from 'lucide-svelte';
+  import { Search, CheckCircle2, Clock, X, Trash2, ClipboardList, Filter } from 'lucide-svelte';
 
   let submissions = [];
   let filtered = [];
@@ -35,14 +32,6 @@
     return () => {
       // No cleanup needed now
     };
-  }
-
-  // Check if user is authorized
-  $: isAuthorized = $user && $userProfile?.is_officer;
-
-  // Load data when authorized
-  $: if (isAuthorized) {
-    loadSubmissions(true);
   }
 
   // Apply filters when submissions or filters change
@@ -187,21 +176,14 @@
     const cleanup = setupEventHandlers();
     cleanupFunctions.push(cleanup);
 
-    // Initial load if authorized
-    if (isAuthorized) {
-      loadSubmissions(true);
-    }
+    // Access control is enforced by officers/+layout; officers only reach here.
+    loadSubmissions(true);
   });
 
   onDestroy(() => {
     // Cleanup all event listeners
     cleanupFunctions.forEach((cleanup) => cleanup());
   });
-
-  // Reload when navigating to view all page
-  $: if ($page.url.pathname === "/officers/view-all" && isAuthorized) {
-    loadSubmissions(true);
-  }
 </script>
 
 <Hero
@@ -215,26 +197,6 @@
 <Container size="xl">
   {#if $loading}
     <LoadingSpinner message="Loading all submissions..." />
-  {:else if !$user}
-    <div class="empty-state-with-icon">
-      <Lock size={48} strokeWidth={2} class="empty-icon" />
-      <EmptyState
-        title="Authentication Required"
-        message="Please log in to view all submissions."
-        actionLabel="Sign In"
-        actionHref="/login"
-      />
-    </div>
-  {:else if !$userProfile?.is_officer}
-    <div class="empty-state-with-icon">
-      <AlertTriangle size={48} strokeWidth={2} class="empty-icon" />
-      <EmptyState
-        title="Access Restricted"
-        message="Officer privileges are required to view all submissions."
-        actionLabel="Back to Officer Tools"
-        actionHref="/officers"
-      />
-    </div>
   {:else}
     <!-- Filter Controls -->
     <div class="controls-section">


### PR DESCRIPTION
## Summary
Consolidates officer-route access control behind a single shared layout guard, fixing the profile-load flash and eliminating the per-page guard drift. Resolves the umbrella issue #56 and its sub-tasks #59, #63, and #66.

## The core change
**New `src/routes/officers/+layout.svelte`** — the single access-control enforcement point for every `/officers/*` route:
- Resolves the auth user via `supabase.auth.getUser()`, reuses or fetches the profile, then gates `<slot />`.
- Keeps a **`loading` state distinct from `denied`** and only mounts the page slot once the user is confirmed to be an officer — so protected content (and any store data) can no longer flash before `$userProfile` resolves (**#63**).
- Non-officers get a consistent access-denied state; unauthenticated users redirect to `/login`; a reactive re-gate handles sign-out mid-session.
- Nested dynamic routes (`manage-competitions/edit/[id]`, etc.) inherit the guard automatically via SvelteKit layout nesting.

## Removed / cleaned up
- **~18 redundant per-page guards** across 15 pages, collapsing the three inconsistent patterns (`goto('/')`, `accessDenied` flags, `isAuthorized` branches) and the imports they left dead.
- **`reports/+page.svelte`** (**#66**): dropped the brittle `$page.url.pathname`-sniffing that self-selected a title/feature list at runtime (the route only ever renders at `/officers/reports`). Now a static "Reports Dashboard" placeholder. This was previously **the one officer page with no guard at all** (**#56**) — now covered by the layout.

## Preserved (finer-grained authz)
- **`entries/[id]`** keeps its Competition-Director-only check, now documented as a deliberate two-layer model: the layout enforces the `is_officer` baseline, and this page restricts entry management further to Competition Directors (**#56** action 2). Verified consistent — the data model sets `is_officer = ['officer','competition_director','vice_president','president'].includes(role)`, so CDs always pass the baseline.
- **`members`** keeps its president / vice-president role logic.

## Verification
- `svelte-check` → **0 errors** (67 pre-existing warnings)
- `npm run build` → **succeeds**
- Not done: live browser E2E of the three states (officer / non-officer / logged-out) requires Supabase credentials — a manual smoke test is recommended before merge.

## Note on #57
#56/#59 list the authz model (#57) as a dependency. The `is_officer`-superset relationship holds in the current code, so this works today; the layout's baseline check is the single place to revisit if the role model changes.

Closes #56
Closes #59
Closes #63
Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)