### PR TITLE
fix(push): persist rotated push subscriptions instead of silently losing them (#74)

### DIFF
--- a/src/lib/components/NotificationPermission.svelte
+++ b/src/lib/components/NotificationPermission.svelte
@@ -11,6 +11,10 @@
 
   const VAPID_PUBLIC_KEY = import.meta.env.VITE_VAPID_PUBLIC_KEY;
 
+  // Tracks the last (user, endpoint) pair we successfully saved to the server,
+  // so we only re-POST when the subscription was rotated or the user changed.
+  const SYNC_MARKER_KEY = 'jax-push-synced-subscription';
+
   onMount(async () => {
     if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
     supported = true;
@@ -19,10 +23,50 @@
       const reg = await navigator.serviceWorker.ready;
       currentSubscription = await reg.pushManager.getSubscription();
       subscribed = !!currentSubscription;
+
+      // The browser can rotate a push subscription (pushsubscriptionchange)
+      // while the service worker has no way to authenticate to
+      // /api/push/subscribe, so renewed subscriptions were silently lost (#74).
+      // Re-sync the live subscription here, where we do have the session.
+      if (currentSubscription) {
+        await syncSubscription(currentSubscription);
+      }
     } catch (err) {
       console.error('Error checking push subscription:', err);
     }
   });
+
+  /**
+   * Persist the current subscription to the server if it differs from the
+   * last one we saved (rotated endpoint, or a different signed-in member).
+   * The server upserts on endpoint, so this is idempotent.
+   * @param {PushSubscription} subscription
+   */
+  async function syncSubscription(subscription) {
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) return; // not signed in — retry on a later load
+
+      const marker = `${session.user.id}|${subscription.endpoint}`;
+      if (localStorage.getItem(SYNC_MARKER_KEY) === marker) return; // already saved
+
+      const response = await fetch('/api/push/subscribe', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`
+        },
+        body: JSON.stringify({ subscription })
+      });
+
+      if (response.ok) {
+        localStorage.setItem(SYNC_MARKER_KEY, marker);
+      }
+    } catch (err) {
+      // Non-fatal: the next app load retries.
+      console.warn('Failed to re-sync push subscription:', err);
+    }
+  }
 
   async function toggle() {
     if (!supported) {
@@ -68,6 +112,10 @@
 
       if (!response.ok) throw new Error('Failed to save subscription');
 
+      if (session?.user) {
+        localStorage.setItem(SYNC_MARKER_KEY, `${session.user.id}|${subscription.endpoint}`);
+      }
+
       currentSubscription = subscription;
       subscribed = true;
       toast.success('Notifications enabled!');
@@ -92,6 +140,7 @@
         body: JSON.stringify({ endpoint })
       });
 
+      localStorage.removeItem(SYNC_MARKER_KEY);
       currentSubscription = null;
       subscribed = false;
       toast.success('Notifications disabled.');

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -108,17 +108,18 @@ sw.addEventListener('notificationclick', (event) => {
   );
 });
 
-// Handle expired subscriptions
+// Handle expired subscriptions: renew the browser-side subscription so push
+// keeps working. The service worker cannot authenticate to /api/push/subscribe
+// (the Supabase session lives in localStorage, unreachable from a SW), so the
+// old unauthenticated POST here always 401ed and the renewed subscription was
+// silently lost. Persisting is now done by NotificationPermission.svelte on
+// the next app load, which re-syncs whenever the endpoint changes (#74).
 sw.addEventListener('pushsubscriptionchange', (event) => {
   event.waitUntil(
-    sw.registration.pushManager
-      .subscribe(event.oldSubscription.options)
-      .then((subscription) =>
-        fetch('/api/push/subscribe', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ subscription })
-        })
-      )
+    (async () => {
+      const options = event.oldSubscription?.options;
+      if (!options) return; // nothing to renew from
+      await sw.registration.pushManager.subscribe(options);
+    })()
   );
 });


### PR DESCRIPTION
## Summary
Fixes #74: the SW's `pushsubscriptionchange` handler POSTed renewed subscriptions to `/api/push/subscribe` **without an Authorization header**, and that endpoint 401s without a Bearer token — so every browser-rotated subscription silently failed to persist and the member eventually vanished from `push_subscriptions` (stale endpoint pruned on the next 410).

## Approach
A service worker can't read the Supabase session (`localStorage` is unreachable from SW context), so persistence moves to page context:

- **`NotificationPermission.svelte`** — on app load, if a live subscription exists, re-sync it to the server whenever the `(user id, endpoint)` pair differs from the last successful save (tracked in a `localStorage` marker, so the common case costs zero network requests). The server upserts on `endpoint`, so the re-POST is idempotent. Keying the marker on user id also re-claims the endpoint when a different member signs in on the same browser (adjacent to #58).
- **`service-worker.js`** — `pushsubscriptionchange` now only renews the browser-side subscription (with a null-guard on `event.oldSubscription`); the doomed unauthenticated fetch is removed and the constraint documented.

## Failure-mode walkthrough
1. Browser rotates subscription in the background → SW renews it browser-side (as before)
2. Next time the member opens the app → `onMount` sees the new endpoint ≠ marker → POSTs with auth → server upserts → marker updated
3. If they're signed out at that moment, the sync is skipped and retried on a later load

The residual gap (member never opens the app again before the old endpoint 410s) existed before and is unfixable without SW-accessible credentials.

## Verification
- `svelte-check` → 0 errors; production build passes
- Push rotation can't be triggered locally — worth a staging sanity check that enable/disable notifications still round-trips (marker set on enable, cleared on disable)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)