### PR TITLE
ci: add svelte-check, stylelint, build, and audit gates (#79)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Fast guard with zero dependencies — checkout + Node is all it needs.
   inline-styles:
     name: Inline style guard
     runs-on: ubuntu-latest
@@ -22,6 +23,52 @@ jobs:
         with:
           node-version: '22'
 
-      # The guard has no dependencies, so a checkout + Node is all it needs.
       - name: Check for hard-coded inline styles (issue #64)
         run: node scripts/check-inline-styles.js
+
+  # Type-check, stylelint, and production build (issue #79).
+  quality:
+    name: svelte-check, stylelint, build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Stylelint
+        run: npm run lint:css
+
+      - name: svelte-check
+        run: npm run check
+
+      - name: Build
+        run: npm run build
+
+  # Dependency audit — visible but non-blocking to start (issue #79).
+  audit:
+    name: npm audit (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit production dependencies (high+)
+        run: npm audit --omit=dev --audit-level=high

--- a/src/routes/officers/approvals/+page.svelte
+++ b/src/routes/officers/approvals/+page.svelte
@@ -490,7 +490,6 @@
     background: var(--color-bg-primary);
     border-radius: var(--radius-button);
     padding: var(--space-6);
-    margin-bottom: var(--space-8);
     box-shadow: var(--shadow-card);
     border-left: 4px solid var(--color-brand-primary);
     display: flex;

--- a/src/routes/officers/manage-competitions/results/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/results/[id]/+page.svelte
@@ -733,9 +733,6 @@
     }
   }
 
-  @media (max-width: 480px) {
-  }
-
   /* Brewer name privacy styles */
   .brewer-name-hidden {
     color: var(--color-text-tertiary);


### PR DESCRIPTION
## Summary
CI previously gated PRs on the inline-style guard only — a broken template or failed build could merge silently. This adds the missing gates to `lint.yml` and unblocks `lint:css` by fixing the two pre-existing stylelint errors.

## New CI jobs (alongside the existing zero-dependency inline-style guard)
- **quality** — `npm ci` → `lint:css` (stylelint) → `svelte-check` → production build. All blocking.
- **audit** — `npm audit --omit=dev --audit-level=high`, **non-blocking** (`continue-on-error`) to start per the issue; tighten later once it's proven stable. It currently passes even as a blocking gate.

Both use Node 22 with npm caching.

## Stylelint fixes (were blocking `lint:css`)
- `officers/approvals/+page.svelte` — duplicate `margin-bottom: var(--space-8)` on `.summary-card`; values were identical, so removing one is a zero-visual-change fix
- `officers/manage-competitions/results/[id]/+page.svelte` — removed the empty `@media (max-width: 480px) {}` block

## Verification (all run locally exactly as CI will)
- YAML validates
- `npm run lint:css` → exit 0 (warnings only — the pre-existing `color-no-hex` warnings don't fail stylelint)
- `npm run check` → 0 errors
- `npm run build` → passes
- `npm audit --omit=dev --audit-level=high` → exit 0

No conflicts with #89 — it touches none of these files, and these jobs pass on that branch's toolchain too (verified during the Svelte 5 work).

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)