### PR TITLE
fix(stores): single profile fetch path, remove store-level setTimeout hack (#61, #76)

### DIFF
--- a/src/lib/stores/userProfile.js
+++ b/src/lib/stores/userProfile.js
@@ -1,5 +1,4 @@
-import { writable } from 'svelte/store';
-import { browser } from '$app/environment';
+import { writable, get } from 'svelte/store';
 import { supabase } from '$lib/supabaseClient';
 
 export const userProfile = writable(null);
@@ -8,16 +7,32 @@ export const isLoadingProfile = writable(false);
 let lastLoaded = 0;
 const CACHE_MS = 10000; // 10 seconds cache
 
-// Simple reset function - only addition to your original  
 export function resetUserProfile() {
-  console.log('🔄 Resetting user profile store');
   userProfile.set(null);
   isLoadingProfile.set(false);
   lastLoaded = 0;
 }
 
+/**
+ * Single fetch path for the signed-in member's profile (#76).
+ *
+ * Returns the profile row, or null when there is no auth user or no matching
+ * members row. Throws on unexpected/transient failures (network, DB) WITHOUT
+ * clobbering an already-loaded profile, so callers can distinguish
+ * "couldn't verify" from "verified absent" (see officers/+layout).
+ *
+ * History (#61): this used to defer userProfile.set() with setTimeout(0)
+ * (commit 972b83e) as a tab-switch staleness workaround. The real fix for the
+ * supabase-js auth-lock hang on tab refocus is deferring work out of
+ * onAuthStateChange, which the root layout does. The store now sets the
+ * profile synchronously and BEFORE isLoadingProfile flips false, so there is
+ * no window where the profile is null-but-not-loading.
+ *
+ * @param {boolean} force bypass the cache
+ * @returns {Promise<object | null>}
+ */
 export async function loadUserProfile(force = false) {
-  if (!force && Date.now() - lastLoaded < CACHE_MS) return;
+  if (!force && Date.now() - lastLoaded < CACHE_MS) return get(userProfile);
 
   isLoadingProfile.set(true);
 
@@ -28,9 +43,8 @@ export async function loadUserProfile(force = false) {
     } = await supabase.auth.getUser();
 
     if (authError || !user) {
-      console.error('User not logged in or failed to retrieve auth user:', authError);
       userProfile.set(null);
-      return;
+      return null;
     }
 
     const { data, error } = await supabase
@@ -40,22 +54,18 @@ export async function loadUserProfile(force = false) {
       .single();
 
     if (error) {
-      console.error('Failed to load user profile:', error);
-      userProfile.set(null);
-    } else {
-      if (browser) {
-        setTimeout(() => {
-          userProfile.set(data);
-          lastLoaded = Date.now();
-        }, 0);
-      } else {
-        userProfile.set(data);
+      // No members row for this auth user — a definitive answer, not a failure.
+      if (error.code === 'PGRST116') {
+        userProfile.set(null);
         lastLoaded = Date.now();
+        return null;
       }
+      throw error;
     }
-  } catch (err) {
-    console.error('❌ Failed to load user profile:', err);
-    userProfile.set(null);
+
+    userProfile.set(data);
+    lastLoaded = Date.now();
+    return data;
   } finally {
     isLoadingProfile.set(false);
   }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { supabase } from '$lib/supabaseClient';
   import { user } from '$lib/stores/user';
-  import { userProfile } from '$lib/stores/userProfile';
+  import { userProfile, loadUserProfile } from '$lib/stores/userProfile';
   import toast, { Toaster } from 'svelte-french-toast';
   import { goto } from '$app/navigation';
   import { ArrowLeft, Home, LogOut, User } from 'lucide-svelte';
@@ -14,21 +14,6 @@
   let subscription;
 
   $: userInitial = $userProfile?.name?.charAt(0)?.toUpperCase() || $user?.email?.charAt(0)?.toUpperCase() || '';
-
-  async function fetchUserProfile(userId) {
-    try {
-      const { data, error } = await supabase
-        .from('members')
-        .select('*')
-        .eq('id', userId)
-        .single();
-      if (error) throw error;
-      userProfile.set(data);
-    } catch (err) {
-      console.error('Failed to fetch profile:', err);
-      userProfile.set(null);
-    }
-  }
 
   async function checkForApprovals(userId) {
     try {
@@ -79,7 +64,7 @@
         user.set(currentUser);
 
         if (currentUser) {
-          await fetchUserProfile(currentUser.id);
+          await loadUserProfile(true).catch((err) => console.error('Failed to load profile:', err));
           await checkForApprovals(currentUser.id);
         }
 
@@ -91,7 +76,7 @@
               user.set(u);
 
               if (event === 'SIGNED_IN' && u) {
-                await fetchUserProfile(u.id);
+                await loadUserProfile(true).catch((err) => console.error('Failed to load profile:', err));
                 await checkForApprovals(u.id);
                 if (window.location.pathname === '/login') goto('/');
               }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,7 +20,7 @@
     loadApprovals(true);
     loadCategoryData(true);
     loadLeaderboard(true);
-    loadUserProfile(true);
+    loadUserProfile(true).catch((err) => console.error('Failed to load profile:', err));
     loadCompetitionData(true);
     loadMyEntries(true);
   }

--- a/src/routes/officers/+layout.svelte
+++ b/src/routes/officers/+layout.svelte
@@ -4,7 +4,7 @@
   import { goto } from '$app/navigation';
   import { supabase } from '$lib/supabaseClient';
   import { user } from '$lib/stores/user';
-  import { userProfile } from '$lib/stores/userProfile';
+  import { userProfile, loadUserProfile } from '$lib/stores/userProfile';
   import { Container, LoadingSpinner, EmptyState, Button } from '$lib/components/ui';
 
   /**
@@ -36,23 +36,12 @@
       }
 
       // Reuse a profile the root layout already loaded for this user; otherwise
-      // fetch it directly so the gate never keys on a still-loading null.
+      // the shared store loader fetches it (#76). It returns null only for a
+      // definitive "no member row"; transient failures throw into the catch
+      // below — so a real officer is never denied over a network blip.
       let profile = get(userProfile);
       if (!profile || profile.id !== authUser.id) {
-        const { data, error } = await supabase
-          .from('members')
-          .select('*')
-          .eq('id', authUser.id)
-          .single();
-
-        // Couldn't verify — don't deny a possibly-legitimate officer; let them retry.
-        if (error) {
-          authState = 'error';
-          return;
-        }
-
-        profile = data;
-        userProfile.set(profile);
+        profile = await loadUserProfile(true);
       }
 
       authState = profile?.is_officer ? 'authorized' : 'denied';


### PR DESCRIPTION
## Summary
Consolidates the three profile-fetch implementations into `loadUserProfile()` (#76) and removes the store-level `setTimeout(0)` hack (#61) — **while deliberately keeping the root layout's `onAuthStateChange` defer**, which is Supabase's documented workaround for the auth-lock hang on tab refocus and the part that actually fixed the original stale-tab bug (commit `972b83e`).

## ⚠️ Do not merge until the tab-switch protocol passes
The store hack was insurance against the tab-switch staleness Matt hit personally. Two things have changed since it was written: supabase-js moved 2.49.7 → 2.110.0 (#85, years of upstream lock/refresh fixes), and the documented-workaround defer in the root layout is preserved. But the removal must be **proven** on a real session (details in the [#61 comment](https://github.com/MattPOlson/jax-points-tracker/issues/61)):
1. Sign in, background the tab 5–10+ minutes (past token refresh)
2. Return → profile-dependent UI (name, officer tools) refreshes **without a reload**
3. Immediately trigger a Supabase query on refocus → no hang
4. Ideally repeat on mobile Safari/Chrome with the tab discarded

## Changes
- **`userProfile.js`** — single fetch path: returns the profile; sets it **before** `isLoadingProfile` flips false (closes the null-but-not-loading window, #63 family); distinguishes "no member row" (PGRST116 → `null`) from transient failures (throws, without clobbering a loaded profile); cache behavior unchanged
- **Root layout** — drops its duplicate `fetchUserProfile()`, calls the store with its own `.catch` so a transient profile failure can't trip init's catch-all (which would clear the whole session); the `setTimeout` defer around the auth callback **stays**
- **`officers/+layout`** — uses the store loader; its retryable `error` state now keys off the loader throwing, so a real officer is still never denied over a network blip, and "authenticated but no members row" correctly lands in `denied`
- **Home page** — fire-and-forget call gains a `.catch` (the loader can now throw)

## Verification
- `svelte-check` → 0 errors; production build passes
- CRLF preserved in the root layout; no line-ending noise in the diff
- The one thing code review can't verify is the tab-switch behavior — that's the manual gate above

Closes #61
Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)