### PR TITLE
perf(db): batch Supabase queries in dashboard and competition loaders (#62, #75)

### DIFF
--- a/src/lib/stores/competitionJudgingStore.js
+++ b/src/lib/stores/competitionJudgingStore.js
@@ -271,6 +271,47 @@ class CompetitionJudgingStore {
     }
   }
 
+  // Bulk-assign judges with a single insert instead of one round-trip
+  // per member (#75).
+  async assignJudges(competitionId, judgeDataList) {
+    if (!judgeDataList?.length) return [];
+
+    try {
+      const rows = judgeDataList.map((judgeData) => ({
+        competition_id: competitionId,
+        judge_id: judgeData.judge_id,
+        judge_role: judgeData.judge_role || JUDGE_ROLES.CLUB_JUDGE,
+        assignment_notes: judgeData.assignment_notes || null,
+        assigned_at: new Date().toISOString(),
+        assigned_by: judgeData.assigned_by,
+        active: true,
+        table_id: judgeData.table_id || null
+      }));
+
+      const { data, error } = await supabase
+        .from('competition_judges')
+        .insert(rows)
+        .select(`
+          *,
+          judge:members!competition_judges_judge_id_fkey(id, name, email, phone),
+          competition:competitions(id, name, judging_date)
+        `);
+
+      if (error) throw error;
+
+      // Update local store
+      judgeStore.update(store => ({
+        ...store,
+        judges: [...store.judges, ...(data || [])]
+      }));
+
+      return data;
+    } catch (err) {
+      console.error('Error assigning judges:', err);
+      throw err;
+    }
+  }
+
   // Remove judge assignment
   async removeJudge(assignmentId) {
     try {

--- a/src/routes/judge/competition/[id]/rankings/+page.svelte
+++ b/src/routes/judge/competition/[id]/rankings/+page.svelte
@@ -119,24 +119,28 @@
 
         if (groupsError) throw groupsError;
 
-        // For each ranking group, count entries
+        // Count entries per group from a single query for all of the
+        // competition's entries, bucketed in memory (#75) — previously one
+        // round-trip per ranking group.
+        const { data: allEntries, error: entriesError } = await supabase
+          .from('competition_entries')
+          .select('id, bjcp_category_id')
+          .eq('competition_id', competitionId);
+
+        if (entriesError) throw entriesError;
+
         const groupsWithCounts = [];
         for (const group of rankingGroups || []) {
           const categoryIds = group.bjcp_category_ids;
-          
-          const { data: entriesData, error: entriesError } = await supabase
-            .from('competition_entries')
-            .select('id, bjcp_category_id')
-            .eq('competition_id', competitionId)
-            .in('bjcp_category_id', categoryIds);
+          const entryCount = (allEntries || []).filter((entry) =>
+            categoryIds.includes(entry.bjcp_category_id)
+          ).length;
 
-          if (entriesError) throw entriesError;
-
-          if (entriesData && entriesData.length > 0) {
+          if (entryCount > 0) {
             groupsWithCounts.push({
               ...group,
               isCustomGroup: true,
-              entryCount: entriesData.length,
+              entryCount,
               displayName: group.group_name
             });
           }

--- a/src/routes/officers/+page.svelte
+++ b/src/routes/officers/+page.svelte
@@ -30,35 +30,37 @@
     try {
       statsLoading = true;
 
-      const { data: pendingData, error: pendingError } = await supabase
-        .from('point_submissions')
-        .select('id')
-        .neq('approved', true);
-
-      if (pendingError) throw pendingError;
-      pendingReviews = pendingData?.length || 0;
-
-      const { data: membersData, error: membersError } = await supabase
-        .from('members')
-        .select('id')
-        .eq('active', true);
-
-      if (membersError) throw membersError;
-      activeMembers = membersData?.length || 0;
-
       const now = new Date();
       const firstDayOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
       const firstDayOfNextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1);
 
-      const { data: pointsData, error: pointsError } = await supabase
-        .from('point_submissions')
-        .select('points')
-        .gte('submitted_at', firstDayOfMonth.toISOString())
-        .lt('submitted_at', firstDayOfNextMonth.toISOString())
-        .eq('approved', true);
+      // Counts use head:true so only the count travels over the wire (#62),
+      // and the three independent stat queries run in parallel (#75).
+      const [pendingRes, membersRes, pointsRes] = await Promise.all([
+        supabase
+          .from('point_submissions')
+          .select('id', { count: 'exact', head: true })
+          .neq('approved', true),
+        supabase
+          .from('members')
+          .select('id', { count: 'exact', head: true })
+          .eq('active', true),
+        supabase
+          .from('point_submissions')
+          .select('points')
+          .gte('submitted_at', firstDayOfMonth.toISOString())
+          .lt('submitted_at', firstDayOfNextMonth.toISOString())
+          .eq('approved', true)
+      ]);
 
-      if (pointsError) throw pointsError;
-      pointsThisMonth = pointsData?.reduce((sum, submission) => sum + (submission.points || 0), 0) || 0;
+      if (pendingRes.error) throw pendingRes.error;
+      pendingReviews = pendingRes.count || 0;
+
+      if (membersRes.error) throw membersRes.error;
+      activeMembers = membersRes.count || 0;
+
+      if (pointsRes.error) throw pointsRes.error;
+      pointsThisMonth = pointsRes.data?.reduce((sum, submission) => sum + (submission.points || 0), 0) || 0;
 
       await competitionManagementStore.loadCompetitions();
 

--- a/src/routes/officers/manage-competitions/judges/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/judges/[id]/+page.svelte
@@ -262,14 +262,16 @@
     try {
       isSaving = true;
 
-      for (const member of availableJudges) {
-        await competitionJudgingStore.assignJudge(competitionId, {
+      // Single bulk insert instead of one round-trip per member (#75).
+      await competitionJudgingStore.assignJudges(
+        competitionId,
+        availableJudges.map((member) => ({
           judge_id: member.id,
           judge_role: JUDGE_ROLES.CLUB_JUDGE,
           assignment_notes: 'Auto-assigned for intraclub competition',
           assigned_by: $userProfile.id
-        });
-      }
+        }))
+      );
 
       await loadData();
 

--- a/src/routes/officers/manage-competitions/judging-dashboard/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/judging-dashboard/[id]/+page.svelte
@@ -427,31 +427,38 @@
       });
     }
 
-    // Upsert results into competition_results table
-    for (const result of finalResults) {
-      // Check if result exists
-      const { data: existing } = await supabase
-        .from('competition_results')
-        .select('id')
-        .eq('competition_id', competitionId)
-        .eq('entry_id', result.entry_id)
-        .single();
+    // Upsert results into competition_results: previously 2 sequential
+    // round-trips per entry (select, then insert/update). Now one fetch of
+    // the existing rows, one bulk insert, and the updates in parallel (#75).
+    const { data: existingResults, error: existingError } = await supabase
+      .from('competition_results')
+      .select('id, entry_id')
+      .eq('competition_id', competitionId);
+    if (existingError) throw existingError;
 
-      if (existing) {
-        // Update existing
+    const existingByEntry = new Map(
+      (existingResults || []).map((row) => [row.entry_id, row.id])
+    );
+
+    const toInsert = finalResults.filter((r) => !existingByEntry.has(r.entry_id));
+    const toUpdate = finalResults.filter((r) => existingByEntry.has(r.entry_id));
+
+    if (toInsert.length > 0) {
+      const { error } = await supabase
+        .from('competition_results')
+        .insert(toInsert);
+      if (error) throw error;
+    }
+
+    await Promise.all(
+      toUpdate.map(async (result) => {
         const { error } = await supabase
           .from('competition_results')
           .update(result)
-          .eq('id', existing.id);
+          .eq('id', existingByEntry.get(result.entry_id));
         if (error) throw error;
-      } else {
-        // Insert new
-        const { error } = await supabase
-          .from('competition_results')
-          .insert([result]);
-        if (error) throw error;
-      }
-    }
+      })
+    );
   }
 
   async function publishResults() {


### PR DESCRIPTION
## Summary
Eliminates the row-fetching counts (#62) and the real N+1 query patterns (#75) found in the competition flows. Each fix replaces per-item round-trips with one (or a constant number of) queries.

## Changes

**Officer dashboard (#62)** — `officers/+page.svelte`
- Pending-review + active-member counts now use `{ count: 'exact', head: true }` — only the count crosses the wire instead of every row
- The three independent stat queries run in parallel (`Promise.all`)

**Rankings loader (#75)** — `judge/competition/[id]/rankings`
- One query for all the competition's entries, bucketed per ranking group in memory — was one round-trip per group

**Results save (#75)** — `judging-dashboard/[id]` `saveResults`
- Was **2 sequential round-trips per entry** (select-then-insert/update). Now: one fetch of existing rows → one bulk insert of new results → updates in parallel
- Bonus correctness: the old `.single()` existence check errored on duplicate rows and treated them as "not existing" (inserting again); the new map-based check updates the existing row instead

**Bulk judge assignment (#75)** — new `competitionJudgingStore.assignJudges()`
- `assignAllMembers` was ~30 serial inserts for an intraclub competition; now a single bulk `insert(rows)` with the same select/store-update semantics as `assignJudge`

## Investigated, deliberately unchanged
- `competitions/results:51` and `officers/.../results/[id]:83` from #75's original list are **in-memory loops** (false positives — noted on the issue)
- `entryNumber.js` awaits in a loop **by design** (uniqueness-collision retry)

## Verification
- `svelte-check` → 0 errors; production build passes
- CRLF preserved in the four CRLF files — diff has zero line-ending noise
- Worth a quick manual pass on: officer dashboard stat tiles, custom-group rankings page, "Assign All" judges button, and saving/publishing results on the judging dashboard

Closes #62
Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)