### PR TITLE
fix(push): validate send payload server-side, same-origin notification URLs (#83)

### DIFF
--- a/src/routes/api/push/send/+server.js
+++ b/src/routes/api/push/send/+server.js
@@ -52,11 +52,23 @@ export async function POST({ request }) {
   }
 
   // Only same-origin relative paths may ride in a notification: a push from
-  // the club app carries implicit trust, so an absolute/protocol-relative URL
-  // would make it a phishing amplifier (#83). The service worker enforces the
-  // same rule when the notification is clicked.
-  const safeUrl =
-    typeof url === 'string' && url.startsWith('/') && !url.startsWith('//') ? url : '/';
+  // the club app carries implicit trust, so a URL resolving off-origin would
+  // make it a phishing amplifier (#83). Resolve against a sentinel origin
+  // rather than string-prefix checks — the URL parser treats "\" as "/" and
+  // strips tabs/newlines, so "/\evil.com" would sneak past startsWith('/').
+  // The service worker enforces the same rule when the notification is clicked.
+  let safeUrl = '/';
+  if (typeof url === 'string') {
+    try {
+      const sentinel = 'https://sentinel.invalid';
+      const parsed = new URL(url, sentinel);
+      if (parsed.origin === sentinel) {
+        safeUrl = parsed.pathname + parsed.search + parsed.hash;
+      }
+    } catch {
+      // Unparseable — fall back to '/'
+    }
+  }
 
   webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
 

--- a/src/routes/api/push/send/+server.js
+++ b/src/routes/api/push/send/+server.js
@@ -45,6 +45,19 @@ export async function POST({ request }) {
     throw error(400, 'Title and message are required');
   }
 
+  // Server-side caps mirroring the client form limits — the client's
+  // maxlength attributes are advisory only (#83).
+  if (title.trim().length > 100 || message.trim().length > 200) {
+    throw error(400, 'Title is limited to 100 characters and message to 200');
+  }
+
+  // Only same-origin relative paths may ride in a notification: a push from
+  // the club app carries implicit trust, so an absolute/protocol-relative URL
+  // would make it a phishing amplifier (#83). The service worker enforces the
+  // same rule when the notification is clicked.
+  const safeUrl =
+    typeof url === 'string' && url.startsWith('/') && !url.startsWith('//') ? url : '/';
+
   webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
 
   // Fetch all subscriptions
@@ -63,7 +76,7 @@ export async function POST({ request }) {
   const payload = JSON.stringify({
     title: title.trim(),
     body: message.trim(),
-    url: url || '/'
+    url: safeUrl
   });
 
   const results = await Promise.allSettled(

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -89,7 +89,10 @@ sw.addEventListener('push', (event) => {
 sw.addEventListener('notificationclick', (event) => {
   event.notification.close();
 
-  const url = event.notification.data?.url || '/';
+  const rawUrl = event.notification.data?.url || '/';
+  // Defense-in-depth (#83): only navigate within the app. The send endpoint
+  // already normalizes the URL, but never trust the payload here either.
+  const url = rawUrl.startsWith('/') && !rawUrl.startsWith('//') ? rawUrl : '/';
 
   event.waitUntil(
     sw.clients

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -92,7 +92,18 @@ sw.addEventListener('notificationclick', (event) => {
   const rawUrl = event.notification.data?.url || '/';
   // Defense-in-depth (#83): only navigate within the app. The send endpoint
   // already normalizes the URL, but never trust the payload here either.
-  const url = rawUrl.startsWith('/') && !rawUrl.startsWith('//') ? rawUrl : '/';
+  // Resolve and compare origins instead of prefix checks — the URL parser
+  // treats "\" as "/" and strips tabs/newlines, so "/\evil.com" would sneak
+  // past startsWith('/').
+  let url = '/';
+  try {
+    const parsed = new URL(rawUrl, sw.location.origin);
+    if (parsed.origin === sw.location.origin) {
+      url = parsed.pathname + parsed.search + parsed.hash;
+    }
+  } catch {
+    // Unparseable — fall back to '/'
+  }
 
   event.waitUntil(
     sw.clients


### PR DESCRIPTION
## Summary
Hardens the push-send path per #83 (low severity — officer-only endpoint — but a cheap fix that removes a phishing amplifier).

- **`/api/push/send`**: title/message length caps enforced server-side (100/200, mirroring the client form); `url` normalized to a same-origin relative path (`/...`, rejecting absolute and protocol-relative `//host` forms) before it enters the push payload
- **Service worker `notificationclick`**: applies the same same-origin rule before `navigate`/`openWindow` — defense-in-depth so a notification can never send a member off-site even if a payload sneaks through another way

## Verification
- `svelte-check` → 0 errors
- Endpoint behavior unchanged for legitimate use (the officer form already caps at 100/200 and sends `/` as the url)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)