### PR TITLE
fix(security): add CSP and security headers (#84)

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,0 +1,20 @@
+/**
+ * Security headers for every response (#84).
+ *
+ * The Content-Security-Policy itself is configured in svelte.config.js
+ * (kit.csp) so SvelteKit can nonce its inline startup script; everything
+ * else lives here.
+ */
+export async function handle({ event, resolve }) {
+  const response = await resolve(event);
+
+  response.headers.set('X-Content-Type-Options', 'nosniff');
+  // Legacy complement to the CSP frame-ancestors directive.
+  response.headers.set('X-Frame-Options', 'DENY');
+  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+  // Cloud Run terminates TLS; the app is only ever served over HTTPS.
+  response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+
+  return response;
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -2,6 +2,31 @@ import adapter from '@sveltejs/adapter-node';
 
 export default {
   kit: {
-    adapter: adapter()
+    adapter: adapter(),
+
+    // Content-Security-Policy (#84). SvelteKit injects nonces for its own
+    // inline startup script in 'auto' mode. Notes on the allowances:
+    // - style-src 'unsafe-inline': Svelte applies transition/animation styles
+    //   via inline style attributes, which nonces cannot cover.
+    // - fonts.googleapis.com / fonts.gstatic.com: the DM Sans + Oswald fonts
+    //   loaded from app.html.
+    // - *.supabase.co: auth + PostgREST (https) and realtime (wss).
+    csp: {
+      mode: 'auto',
+      directives: {
+        'default-src': ['self'],
+        'script-src': ['self'],
+        'style-src': ['self', 'unsafe-inline', 'https://fonts.googleapis.com'],
+        'font-src': ['self', 'data:', 'https://fonts.gstatic.com'],
+        'img-src': ['self', 'data:', 'blob:'],
+        'connect-src': ['self', 'https://*.supabase.co', 'wss://*.supabase.co'],
+        'worker-src': ['self'],
+        'manifest-src': ['self'],
+        'object-src': ['none'],
+        'base-uri': ['self'],
+        'frame-ancestors': ['none'],
+        'form-action': ['self']
+      }
+    }
   }
-}; 
+};


### PR DESCRIPTION
## Summary
- Adds `kit.csp` in `svelte.config.js` (auto mode): nonced `script-src 'self'`, `frame-ancestors 'none'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, with allowances for Supabase (`https://*.supabase.co` + `wss://`), Google Fonts, and `data:`/`blob:` images.
- New `src/hooks.server.js` `handle` sets the non-CSP headers: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (camera/mic/geolocation off), and HSTS.

## Notes
- `style-src 'unsafe-inline'` is required because Svelte applies transition/animation styles via inline `style` attributes, which nonces can't cover.
- Google Calendar sync is server-side only (`/api/calendar` fetch) so it needs no `connect-src` entry; the calendar link on `/calendar` is a navigation, not a fetch.
- Web push is delivered by the server via `web-push`, so no push endpoints are needed in `connect-src`.

## Testing
- `npm run build` passes.
- Ran the adapter-node build locally: rendered pages return 200 with the CSP header including a per-request script nonce, plus all hook headers.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)