### PR TITLE
fix(a11y): resolve all 34 svelte-check a11y warnings (#82)

### DIFF
--- a/src/lib/components/ConfirmDialog.svelte
+++ b/src/lib/components/ConfirmDialog.svelte
@@ -17,15 +17,18 @@
 <svelte:window on:keydown={handleKeydown} />
 
 {#if $confirmState.open}
-  <!-- svelte-ignore a11y-no-static-element-interactions -->
-  <div class="backdrop" on:click={() => answer(false)}>
+  <div
+    class="backdrop"
+    role="presentation"
+    on:click={(e) => e.target === e.currentTarget && answer(false)}
+    on:keydown={handleKeydown}
+  >
     <div
       class="dialog"
       role="alertdialog"
       aria-modal="true"
       aria-labelledby="confirm-title"
       aria-describedby="confirm-message"
-      on:click|stopPropagation
     >
       <div class="dialog-header">
         <h2 id="confirm-title" class="dialog-title">{$confirmState.title}</h2>

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -17,7 +17,6 @@
   class:card-accent-info={accent && accentColor === 'info'}
   class:card-no-padding={noPadding}
   class:card-hover={hover}
-  on:click
 >
   <slot />
 </div>

--- a/src/lib/components/ui/Modal.svelte
+++ b/src/lib/components/ui/Modal.svelte
@@ -31,7 +31,12 @@
 <svelte:window on:keydown={handleKeydown} />
 
 {#if open}
-  <div class="modal-backdrop" on:click={handleBackdropClick}>
+  <div
+    class="modal-backdrop"
+    role="presentation"
+    on:click={handleBackdropClick}
+    on:keydown={handleKeydown}
+  >
     <div class="modal modal-{size}" role="dialog" aria-modal="true" aria-labelledby="modal-title">
       <div class="modal-header">
         {#if title}

--- a/src/routes/competitions/my-entries/+page.svelte
+++ b/src/routes/competitions/my-entries/+page.svelte
@@ -1032,9 +1032,14 @@
 
 <!-- Delete Confirmation Modal -->
 {#if showDeleteConfirm}
-  <div class="modal-overlay" on:click={cancelDelete}>
-    <div class="modal-content" on:click|stopPropagation>
-      <h2>🗑️ Delete Entry</h2>
+  <div
+    class="modal-overlay"
+    role="presentation"
+    on:click={(e) => e.target === e.currentTarget && cancelDelete()}
+    on:keydown={(e) => e.key === 'Escape' && cancelDelete()}
+  >
+    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="delete-entry-title">
+      <h2 id="delete-entry-title">🗑️ Delete Entry</h2>
       <p>Are you sure you want to delete this competition entry?</p>
       <p><strong>This action cannot be undone.</strong></p>
 

--- a/src/routes/judge/competition/[id]/rankings/+page.svelte
+++ b/src/routes/judge/competition/[id]/rankings/+page.svelte
@@ -936,6 +936,7 @@
           <div 
             class="category-card {selectedCategory?.id === category.id ? 'selected' : ''}"
             on:click={() => selectCategory(category)}
+            on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectCategory(category); } }}
             role="button"
             tabindex="0"
           >

--- a/src/routes/officers/approvals/+page.svelte
+++ b/src/routes/officers/approvals/+page.svelte
@@ -335,13 +335,16 @@
   {#if showApprovalModal && selectedSubmission}
     <div
       class="modal-overlay"
-      on:click={closeApprovalModal}
+      role="presentation"
+      on:click={(e) => e.target === e.currentTarget && closeApprovalModal()}
       on:keydown={(e) => e.key === "Escape" && closeApprovalModal()}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="approval-modal-title"
     >
-      <div class="modal approval-modal" on:click|stopPropagation>
+      <div
+        class="modal approval-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="approval-modal-title"
+      >
         <div class="modal-header">
           <h3 id="approval-modal-title">
             <CheckCircle size={20} strokeWidth={2} class="icon-inline" />
@@ -411,13 +414,16 @@
   {#if showRejectModal && selectedSubmission}
     <div
       class="modal-overlay"
-      on:click={closeRejectModal}
+      role="presentation"
+      on:click={(e) => e.target === e.currentTarget && closeRejectModal()}
       on:keydown={(e) => e.key === "Escape" && closeRejectModal()}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="reject-modal-title"
     >
-      <div class="modal reject-modal" on:click|stopPropagation>
+      <div
+        class="modal reject-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="reject-modal-title"
+      >
         <div class="modal-header">
           <h3 id="reject-modal-title">
             <X size={20} strokeWidth={2} class="icon-inline" />

--- a/src/routes/officers/manage-competitions/entries/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/entries/[id]/+page.svelte
@@ -897,6 +897,8 @@ function printLabels() {
     position: relative;
     width: 48px;
     height: 24px;
+    padding: 0;
+    border: none;
     background: var(--color-gray-250);
     border-radius: var(--radius-xl);
     cursor: pointer;
@@ -1391,10 +1393,14 @@ function printLabels() {
                 </td>
                 <td>
                   <div class="payment-toggle">
-                    <div 
+                    <button
+                      type="button"
                       class="toggle-switch {entry.is_paid ? 'active' : ''}"
+                      role="switch"
+                      aria-checked={entry.is_paid}
+                      aria-label="Mark entry as paid"
                       on:click={() => updatePaymentStatus(entry.id, !entry.is_paid)}
-                    ></div>
+                    ></button>
                     <span>{entry.is_paid ? 'Paid' : 'Unpaid'}</span>
                   </div>
                 </td>
@@ -1477,10 +1483,14 @@ function printLabels() {
             <!-- Payment status with toggle -->
             <div class="payment-status-mobile">
               <div class="payment-toggle">
-                <div 
+                <button
+                  type="button"
                   class="toggle-switch {entry.is_paid ? 'active' : ''}"
+                  role="switch"
+                  aria-checked={entry.is_paid}
+                  aria-label="Mark entry as paid"
                   on:click={() => updatePaymentStatus(entry.id, !entry.is_paid)}
-                ></div>
+                ></button>
                 <span>{entry.is_paid ? 'Paid' : 'Unpaid'}</span>
               </div>
             </div>

--- a/src/routes/officers/members/+page.svelte
+++ b/src/routes/officers/members/+page.svelte
@@ -152,6 +152,26 @@
     editedEmail = member.email || '';
     showEditModal = true;
   }
+
+  function closeMemberModal() {
+    showMemberModal = false;
+    selectedMember = null;
+    memberDetails = null;
+  }
+
+  function closeEditModal() {
+    showEditModal = false;
+    memberToEdit = null;
+    editedName = '';
+    editedPhone = '';
+    editedEmail = '';
+  }
+
+  function closeRoleChangeModal() {
+    showRoleChangeModal = false;
+    memberToPromote = null;
+    newRole = '';
+  }
   // Handle role change
   async function handleRoleChange() {
     if (!memberToPromote || !newRole) return;
@@ -511,11 +531,16 @@
 
 <!-- Member Details Modal -->
 {#if showMemberModal && selectedMember}
-  <div class="modal-backdrop" on:click={() => { showMemberModal = false; selectedMember = null; memberDetails = null; }}>
-    <div class="modal-content" on:click|stopPropagation>
+  <div
+    class="modal-backdrop"
+    role="presentation"
+    on:click={(e) => e.target === e.currentTarget && closeMemberModal()}
+    on:keydown={(e) => e.key === 'Escape' && closeMemberModal()}
+  >
+    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="member-details-title">
       <div class="modal-header">
-        <h2>Member Details</h2>
-        <button class="close-button" on:click={() => { showMemberModal = false; selectedMember = null; memberDetails = null; }}>
+        <h2 id="member-details-title">Member Details</h2>
+        <button class="close-button" on:click={closeMemberModal}>
           ✕
         </button>
       </div>
@@ -599,11 +624,16 @@
 
 <!-- Edit Member Modal -->
 {#if showEditModal && memberToEdit}
-  <div class="modal-backdrop" on:click={() => { showEditModal = false; memberToEdit = null; editedName = ''; editedPhone = ''; editedEmail = ''; }}>
-    <div class="modal-content small" on:click|stopPropagation>
+  <div
+    class="modal-backdrop"
+    role="presentation"
+    on:click={(e) => e.target === e.currentTarget && closeEditModal()}
+    on:keydown={(e) => e.key === 'Escape' && closeEditModal()}
+  >
+    <div class="modal-content small" role="dialog" aria-modal="true" aria-labelledby="edit-member-title">
       <div class="modal-header">
-        <h2>Edit Member Information</h2>
-        <button class="close-button" on:click={() => { showEditModal = false; memberToEdit = null; editedName = ''; editedPhone = ''; editedEmail = ''; }}>
+        <h2 id="edit-member-title">Edit Member Information</h2>
+        <button class="close-button" on:click={closeEditModal}>
           ✕
         </button>
       </div>
@@ -652,7 +682,7 @@
         <div class="modal-actions">
           <button 
             class="cancel-button" 
-            on:click={() => { showEditModal = false; memberToEdit = null; editedName = ''; editedPhone = ''; editedEmail = ''; }}
+            on:click={closeEditModal}
             disabled={isUpdatingMember}
           >
             Cancel
@@ -671,11 +701,16 @@
 {/if}
 <!-- Role Change Modal -->
 {#if showRoleChangeModal && memberToPromote}
-  <div class="modal-backdrop" on:click={() => { showRoleChangeModal = false; memberToPromote = null; newRole = ''; }}>
-    <div class="modal-content small" on:click|stopPropagation>
+  <div
+    class="modal-backdrop"
+    role="presentation"
+    on:click={(e) => e.target === e.currentTarget && closeRoleChangeModal()}
+    on:keydown={(e) => e.key === 'Escape' && closeRoleChangeModal()}
+  >
+    <div class="modal-content small" role="dialog" aria-modal="true" aria-labelledby="change-role-title">
       <div class="modal-header">
-        <h2>Change Member Role</h2>
-        <button class="close-button" on:click={() => { showRoleChangeModal = false; memberToPromote = null; newRole = ''; }}>
+        <h2 id="change-role-title">Change Member Role</h2>
+        <button class="close-button" on:click={closeRoleChangeModal}>
           ✕
         </button>
       </div>
@@ -719,7 +754,7 @@
         {/if}
 
         <div class="modal-actions">
-          <button class="cancel-button" on:click={() => { showRoleChangeModal = false; memberToPromote = null; newRole = ''; }}>
+          <button class="cancel-button" on:click={closeRoleChangeModal}>
             Cancel
           </button>
           <button


### PR DESCRIPTION
## Summary
Gets `svelte-check` a11y warnings from **34 → 0**. Remaining 33 warnings are pre-existing `css-unused-selector` noise, untouched.

### Modals (Modal.svelte, ConfirmDialog, my-entries, approvals, members)
- Backdrop: `role="presentation"` + `on:keydown` Escape handling; close fires only when `event.target === event.currentTarget`, so the inner dialog divs no longer need `on:click|stopPropagation` (behavior is identical).
- `role="dialog"` / `aria-modal` / `aria-labelledby` now sit on the dialog element itself (approvals had them on the overlay; members/my-entries had none — headings got ids to label them).
- officers/members: repeated inline close expressions extracted into `closeMemberModal` / `closeEditModal` / `closeRoleChangeModal`.

### Real keyboard fixes
- `entries/[id]`: payment toggle `<div on:click>` → `<button type="button" role="switch" aria-checked>` (CSS gains `border: none; padding: 0` so it renders identically) — keyboard users can now toggle payment.
- `rankings`: category cards already had `role="button" tabindex="0"` but no handler — added Enter/Space activation.
- `Card.svelte`: removed `on:click` forwarding; no consumer passes a click handler, and a clickable card should be a button.

## Testing
- `npm run check`: 0 errors, 0 a11y warnings (was 34).
- `npm run build` passes.
- CRLF files (Card.svelte, rankings) edited with ending-preserving tools; endings verified.

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)