### PR TITLE
fix(ssr): stop realtime client from requiring native WebSocket on the server (#99)

### DIFF
--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -13,8 +13,24 @@ if (!supabaseAnonKey) {
   throw new Error('Missing VITE_SUPABASE_ANON_KEY environment variable');
 }
 
+// supabase-js resolves a WebSocket implementation for realtime eagerly inside
+// createClient(), which throws during SSR on Node < 22 ("native WebSocket not
+// found") and 500s every server-rendered page (#99). This app never opens
+// realtime channels — and certainly not on the server — so give the server
+// client an inert transport; the realtime lookup then never touches the
+// runtime's WebSocket. Browser clients keep the default (native) transport.
+class NoopWebSocket {
+  constructor() {
+    this.readyState = 3; // CLOSED
+  }
+  close() {}
+  send() {}
+  addEventListener() {}
+  removeEventListener() {}
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  ...(browser ? {} : { realtime: { transport: NoopWebSocket } }),
   auth: {
     persistSession: true,
     autoRefreshToken: true,


### PR DESCRIPTION
## Summary
- `createClient()` eagerly resolves a WebSocket constructor for realtime (`RealtimeClient.js:629`), which throws `native WebSocket not found` on Node < 22 and 500s every server-rendered page (#99).
- This app never opens realtime channels — and never on the server — so the SSR client now gets an inert `NoopWebSocket` transport, which short-circuits the native lookup (`options?.transport ?? getWebSocketConstructor()`). Browser clients keep the default native transport, so client-side behavior is unchanged.
- This also settles the issue's open question: the Supabase realtime client intentionally does not run server-side.

Complements #73 (Node 18 → 22 base image bump): even on Node 22 this removes the SSR dependency on a runtime WebSocket global entirely.

## Verification
Production build run under `node --no-experimental-websocket` (simulates the failing runtime — `globalThis.WebSocket` is `undefined`):

| Route | Before | After |
|---|---|---|
| `GET /` | 500, exact #99 stack trace | 200 |
| `GET /officers` | 500 | 200 |
| `GET /officers/reports` | 500 | 200 |

Server log clean — no `native WebSocket not found` errors. `npm run check`: 0 errors.

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)