### PR TITLE
feat(ui): logged-out landing page + honest self-review UX in approvals (#97, #98)

### DIFF
--- a/src/lib/components/LandingPage.svelte
+++ b/src/lib/components/LandingPage.svelte
@@ -1,0 +1,164 @@
+<script>
+  import { goto } from '$app/navigation';
+  import { Hero, Container, Button, OverlappingCard } from '$lib/components/ui';
+  import { Trophy, Award, CalendarDays, Users } from 'lucide-svelte';
+
+  // Shown by the root layout to logged-out visitors instead of app pages
+  // (#97). With RLS, the anon role reads no data, so app pages would only
+  // render empty shells; this never fires a data query.
+  const features = [
+    {
+      icon: Award,
+      title: 'Points & Leaderboard',
+      text: 'Earn points for brewing, judging, and club activity — and see where you stand.'
+    },
+    {
+      icon: Trophy,
+      title: 'Competitions',
+      text: 'Enter club competitions, track your entries, and view published results.'
+    },
+    {
+      icon: CalendarDays,
+      title: 'Events & Calendar',
+      text: 'Meetings, brew days, and festivals — sign up and stay in the loop.'
+    },
+    {
+      icon: Users,
+      title: 'Member Community',
+      text: 'A private portal built by and for Jacksonville homebrewers.'
+    }
+  ];
+</script>
+
+<main>
+  <Hero
+    title="Have Fun Brew Better Beer!"
+    subtitle="Jacksonville Ale Exchange"
+    backgroundImage="/Jax-Banner.png"
+    overlay={true}
+    large={true}
+  />
+
+  <OverlappingCard>
+    <p class="cta-text">
+      The JAX Members Portal is where Jacksonville Ale Exchange members track brewing
+      points, enter competitions, and sign up for club events.
+    </p>
+    <Button variant="primary" size="lg" on:click={() => goto('/login')}>
+      Member Login
+    </Button>
+    <p class="cta-hint">Club data is for members only — sign in to get started.</p>
+  </OverlappingCard>
+
+  <Container size="lg">
+    <section class="features-section">
+      <h2 class="section-title">Inside the Portal</h2>
+      <div class="features-grid">
+        {#each features as feature, i}
+          <div class="feature-card" style="--stagger: {i}">
+            <div class="feature-icon">
+              <svelte:component this={feature.icon} size={32} strokeWidth={1.5} />
+            </div>
+            <h3 class="feature-title">{feature.title}</h3>
+            <p class="feature-text">{feature.text}</p>
+          </div>
+        {/each}
+      </div>
+    </section>
+  </Container>
+</main>
+
+<style>
+  .cta-text {
+    margin: 0 0 var(--space-6);
+    font-size: var(--font-size-lg);
+    color: var(--color-text-primary);
+    line-height: 1.6;
+  }
+
+  .cta-hint {
+    margin: var(--space-4) 0 0;
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .features-section {
+    margin: var(--space-16) 0 var(--space-20);
+  }
+
+  .section-title {
+    font-size: var(--font-size-2xl);
+    color: var(--color-brand-primary);
+    margin-bottom: var(--space-8);
+    font-weight: var(--font-weight-bold);
+    text-align: center;
+  }
+
+  .features-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: var(--space-6);
+  }
+
+  .feature-card {
+    background: var(--color-bg-card);
+    border-radius: var(--radius-md);
+    border-top: 3px solid var(--color-brand-gold);
+    box-shadow: var(--shadow-md, 0 4px 6px rgba(0, 0, 0, 0.1));
+    padding: var(--space-8) var(--space-6);
+    text-align: center;
+    animation: rise-in 0.5s ease-out both;
+    animation-delay: calc(var(--stagger) * 90ms);
+  }
+
+  .feature-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: var(--color-brand-primary);
+    color: var(--color-brand-gold);
+    margin-bottom: var(--space-4);
+  }
+
+  .feature-title {
+    font-family: var(--font-family-display);
+    font-size: var(--font-size-lg);
+    color: var(--color-brand-primary);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin: 0 0 var(--space-2);
+  }
+
+  .feature-text {
+    margin: 0;
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    line-height: 1.6;
+  }
+
+  @keyframes rise-in {
+    from {
+      opacity: 0;
+      transform: translateY(16px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .feature-card {
+      animation: none;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .features-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,10 +6,12 @@
   import { userProfile, loadUserProfile } from '$lib/stores/userProfile';
   import toast, { Toaster } from 'svelte-french-toast';
   import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import { ArrowLeft, Home, LogOut, User } from 'lucide-svelte';
   import NotificationPermission from '$lib/components/NotificationPermission.svelte';
   import InstallPrompt from '$lib/components/InstallPrompt.svelte';
   import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+  import LandingPage from '$lib/components/LandingPage.svelte';
 
   let subscription;
 
@@ -180,7 +182,20 @@
 />
 <InstallPrompt />
 <ConfirmDialog />
-<slot />
+
+<!-- Logged-out visitors get the landing page instead of app pages (#97):
+     with RLS the anon role reads no data, so app pages would only render
+     empty shells — and because they never mount, their onMount data
+     queries never fire. /login stays reachable for the sign-in flow.
+     The user store starts null and flips after getSession resolves, so a
+     signed-in visitor sees the landing only for the moment between
+     hydration and session restore (same window the old empty shells
+     occupied). -->
+{#if $user || $page.url.pathname === '/login'}
+  <slot />
+{:else}
+  <LandingPage />
+{/if}
 
 <style>
   .header-bar {

--- a/src/routes/officers/approvals/+page.svelte
+++ b/src/routes/officers/approvals/+page.svelte
@@ -8,6 +8,7 @@
     loadApprovals,
     loading,
   } from "$lib/stores/approvalsStore.js";
+  import { userProfile } from "$lib/stores/userProfile";
   import { formatDate, formatSubmissionTime } from "$lib/utils/dateUtils.js";
   import { Hero, Container, LoadingSpinner, EmptyState, Button } from '$lib/components/ui';
   import { CheckCircle, X, Lock, AlertTriangle, PartyPopper, RefreshCw, ClipboardList } from 'lucide-svelte';
@@ -57,12 +58,24 @@
 
     isProcessing = true;
     try {
-      const { error } = await supabase
+      const { data, error } = await supabase
         .from("point_submissions")
         .update({ approved: true, updated_at: new Date().toISOString() })
-        .eq("id", selectedSubmission.id);
+        .eq("id", selectedSubmission.id)
+        .select("id");
 
       if (error) throw error;
+
+      // RLS excludes an officer's own submissions from the officer UPDATE
+      // policy (#18), and a 0-row update is not an error to Supabase --
+      // surface it instead of showing a false success (#98).
+      if (!data?.length) {
+        toast.error(
+          "Submission was not updated — another officer must review your own submissions.",
+        );
+        closeApprovalModal();
+        return;
+      }
 
       toast.success(
         `✅ Approved ${selectedSubmission.member.name}'s submission for ${selectedSubmission.points} points!`,
@@ -104,16 +117,27 @@
 
     isProcessing = true;
     try {
-      const { error } = await supabase
+      const { data, error } = await supabase
         .from("point_submissions")
         .update({
           rejection_reason: rejectionReason.trim(),
           approved: false,
           updated_at: new Date().toISOString(),
         })
-        .eq("id", selectedSubmission.id);
+        .eq("id", selectedSubmission.id)
+        .select("id");
 
       if (error) throw error;
+
+      // See confirmApproval: a 0-row update means RLS refused it (own
+      // submission) -- don't show a false success (#98).
+      if (!data?.length) {
+        toast.error(
+          "Submission was not updated — another officer must review your own submissions.",
+        );
+        closeRejectModal();
+        return;
+      }
 
       toast.success(
         `❌ Rejected ${selectedSubmission.member.name}'s submission`,
@@ -221,28 +245,38 @@
                     : "Not available"}
                 </td>
                 <td class="actions-cell">
-                  <div class="action-buttons">
-                    <Button
-                      variant="success"
-                      size="sm"
-                      subtle
-                      disabled={isProcessing}
-                      on:click={() => openApproval(s)}
-                    >
-                      <CheckCircle size={16} strokeWidth={2} />
-                      Approve
-                    </Button>
-                    <Button
-                      variant="danger"
-                      size="sm"
-                      subtle
-                      disabled={isProcessing}
-                      on:click={() => openReject(s)}
-                    >
-                      <X size={16} strokeWidth={2} />
-                      Reject
-                    </Button>
-                  </div>
+                  {#if s.member_id === $userProfile?.id}
+                    <!-- RLS blocks officers from reviewing their own
+                         submissions (#18); say so instead of offering
+                         buttons that silently no-op (#98). -->
+                    <div class="self-review-note">
+                      <Lock size={14} strokeWidth={2} />
+                      <span>Another officer must review this</span>
+                    </div>
+                  {:else}
+                    <div class="action-buttons">
+                      <Button
+                        variant="success"
+                        size="sm"
+                        subtle
+                        disabled={isProcessing}
+                        on:click={() => openApproval(s)}
+                      >
+                        <CheckCircle size={16} strokeWidth={2} />
+                        Approve
+                      </Button>
+                      <Button
+                        variant="danger"
+                        size="sm"
+                        subtle
+                        disabled={isProcessing}
+                        on:click={() => openReject(s)}
+                      >
+                        <X size={16} strokeWidth={2} />
+                        Reject
+                      </Button>
+                    </div>
+                  {/if}
                 </td>
               </tr>
             {/each}
@@ -284,30 +318,39 @@
               </div>
             </div>
 
-            <div class="card-actions">
-              <Button
-                variant="success"
-                size="sm"
-                subtle
-                fullWidth
-                disabled={isProcessing}
-                on:click={() => openApproval(s)}
-              >
-                <CheckCircle size={16} strokeWidth={2} />
-                Approve
-              </Button>
-              <Button
-                variant="danger"
-                size="sm"
-                subtle
-                fullWidth
-                disabled={isProcessing}
-                on:click={() => openReject(s)}
-              >
-                <X size={16} strokeWidth={2} />
-                Reject
-              </Button>
-            </div>
+            {#if s.member_id === $userProfile?.id}
+              <div class="card-actions">
+                <div class="self-review-note">
+                  <Lock size={14} strokeWidth={2} />
+                  <span>Another officer must review this</span>
+                </div>
+              </div>
+            {:else}
+              <div class="card-actions">
+                <Button
+                  variant="success"
+                  size="sm"
+                  subtle
+                  fullWidth
+                  disabled={isProcessing}
+                  on:click={() => openApproval(s)}
+                >
+                  <CheckCircle size={16} strokeWidth={2} />
+                  Approve
+                </Button>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  subtle
+                  fullWidth
+                  disabled={isProcessing}
+                  on:click={() => openReject(s)}
+                >
+                  <X size={16} strokeWidth={2} />
+                  Reject
+                </Button>
+              </div>
+            {/if}
           </div>
         {/each}
       </div>
@@ -612,6 +655,16 @@
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
+  }
+
+  .self-review-note {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    font-style: italic;
+    padding: 0.35rem 0;
   }
 
   /* Mobile Cards */


### PR DESCRIPTION
## Summary

### #97 — landing page for logged-out visitors
New `LandingPage.svelte`, rendered by the **root layout** for any route except `/login` when there's no session:
- Existing brand system throughout — banner `Hero`, `OverlappingCard` intro with **Member Login** CTA, and a four-tile "Inside the Portal" feature overview (points/leaderboard, competitions, events, community) with a staggered rise-in (disabled under `prefers-reduced-motion`)
- Because app pages **never mount** without a session, their `onMount` data queries never fire — the ticket's third checkbox — instead of round-tripping to RLS that returns nothing
- A signed-in visitor hard-refreshing sees the landing only between hydration and session restore — the same window the old empty shells occupied

### #98 — approvals self-review UX
- Rows where `member_id === $userProfile.id` show *"Another officer must review this"* (with the lock icon) instead of Approve/Reject buttons, in both the desktop table and mobile cards
- Defense in depth: both update paths now `.select('id')` and check the affected row count — any future silent 0-row no-op surfaces as an error toast instead of false success (RLS returns no error for 0-row updates)

## Verification (production build)
| Check | Result |
|---|---|
| `GET /`, `/leaderboard`, `/events`, `/officers` logged out | 200, all render the landing (hero copy, Member Login, feature grid in SSR output) |
| `GET /login` | 200, real login page, no landing content |
| `npm run check` | 0 errors |
| Line endings | pre-existing conventions preserved (layout CRLF, approvals LF) |

Officer-session flows (self-review note, 0-row toast) verified by code path against the live RLS policy (`is_officer() AND member_id <> auth.uid()`, confirmed 0-row on self in #106 testing); needs a quick manual click-through with an officer account after deploy.

Closes #97
Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)