### PR TITLE
feat(auth): Discord sign-in + opt-in identity linking on /profile (#50)

### DIFF
--- a/src/lib/components/AuthForm.svelte
+++ b/src/lib/components/AuthForm.svelte
@@ -44,6 +44,28 @@
     password = '';
   }
 
+  // Discord OAuth (#50). Implicit flow: tokens come back to /login in the
+  // URL hash, detectSessionInUrl consumes them, and the login page's
+  // onAuthStateChange handles the redirect -- same path as magic links.
+  // Members with a matching verified email are linked to their existing
+  // account by Supabase; anyone else gets a fresh account (open signup,
+  // same as email).
+  async function signInWithDiscord() {
+    loading = true;
+    message = null;
+    try {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'discord',
+        options: { redirectTo: `${window.location.origin}/login` }
+      });
+      if (error) throw error;
+      // The browser is about to navigate away to Discord.
+    } catch (err) {
+      message = { type: 'error', text: err?.message || 'Could not start Discord sign-in.' };
+      loading = false;
+    }
+  }
+
   async function handleSubmit() {
     loading = true;
     message = null;
@@ -127,6 +149,24 @@
   <button class="auth-button" type="submit" disabled={loading}>
     {loading ? 'Please wait…' : SUBMIT_LABELS[view]}
   </button>
+
+  {#if view === 'sign_in' || view === 'sign_up'}
+    <div class="auth-divider" role="separator"><span>or</span></div>
+    <button
+      type="button"
+      class="discord-button"
+      disabled={loading}
+      on:click={signInWithDiscord}
+    >
+      <svg class="discord-mark" viewBox="0 0 127.14 96.36" aria-hidden="true" focusable="false">
+        <path
+          fill="currentColor"
+          d="M107.7 8.07A105.15 105.15 0 0 0 81.47 0a72.06 72.06 0 0 0-3.36 6.83 97.68 97.68 0 0 0-29.11 0A72.37 72.37 0 0 0 45.64 0a105.89 105.89 0 0 0-26.25 8.09C2.79 32.65-1.71 56.6.54 80.21a105.73 105.73 0 0 0 32.17 16.15 77.7 77.7 0 0 0 6.89-11.11 68.42 68.42 0 0 1-10.85-5.18c.91-.66 1.8-1.34 2.66-2a75.57 75.57 0 0 0 64.32 0c.87.71 1.76 1.39 2.66 2a68.68 68.68 0 0 1-10.87 5.19 77 77 0 0 0 6.89 11.1 105.25 105.25 0 0 0 32.19-16.14c2.64-27.38-4.51-51.11-18.9-72.15ZM42.45 65.69C36.18 65.69 31 60 31 53s5-12.74 11.43-12.74S54 46 53.89 53s-5.05 12.69-11.44 12.69Zm42.24 0C78.41 65.69 73.25 60 73.25 53s5-12.74 11.44-12.74S96.23 46 96.12 53s-5.04 12.69-11.43 12.69Z"
+        />
+      </svg>
+      Continue with Discord
+    </button>
+  {/if}
 
   <div class="auth-links">
     {#if view === 'sign_in'}
@@ -228,6 +268,54 @@
     background-color: var(--color-success-bg);
     color: var(--color-success);
     border: 1px solid var(--color-success-border);
+  }
+
+  .auth-divider {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin: var(--space-4) 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .auth-divider::before,
+  .auth-divider::after {
+    content: '';
+    flex: 1;
+    border-top: 1px solid var(--color-gray-200);
+  }
+
+  .discord-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    width: 100%;
+    padding: 0.875rem;
+    background-color: #5865f2; /* Discord blurple */
+    color: #ffffff;
+    border: none;
+    border-radius: var(--radius-button);
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: var(--font-weight-semibold);
+    transition: background-color var(--transition-base);
+  }
+
+  .discord-button:hover:not(:disabled) {
+    background-color: #4752c4;
+  }
+
+  .discord-button:disabled {
+    opacity: 0.7;
+    cursor: default;
+  }
+
+  .discord-mark {
+    width: 20px;
+    height: 16px;
+    flex-shrink: 0;
   }
 
   .auth-links {

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -2,9 +2,10 @@
   import { onMount, onDestroy } from 'svelte';
   import { supabase } from '$lib/supabaseClient';
   import { userProfile } from '$lib/stores/userProfile';
+  import { showConfirm } from '$lib/stores/confirmDialog.js';
   import toast from 'svelte-french-toast';
   import { Hero, Container, LoadingSpinner, EmptyState, Button, FormInput, Badge, Card } from '$lib/components/ui';
-  import { Edit, Save, RotateCcw, User as UserIcon, Award, Check, X } from 'lucide-svelte';
+  import { Edit, Save, RotateCcw, User as UserIcon, Award, Check, X, Link2, Unlink, Mail } from 'lucide-svelte';
 
   // Local copies of profile fields for editing
   let profile = null;
@@ -154,10 +155,98 @@
     }
   }
 
+  // ---- Linked accounts (#50) -------------------------------------------
+  /** @type {Array<any>} */
+  let identities = [];
+  let identitiesLoading = true;
+  let isLinking = false;
+  let isUnlinking = false;
+
+  $: discordIdentity = identities.find((i) => i.provider === 'discord');
+  // Supabase refuses to unlink the last identity; don't offer a dead button
+  // (covers Discord-created accounts that have no email identity).
+  $: canUnlink = discordIdentity && identities.length > 1;
+
+  function discordDisplayName(identity) {
+    const d = identity?.identity_data ?? {};
+    return d.custom_claims?.global_name || d.full_name || d.name || d.email || 'Discord account';
+  }
+
+  async function loadIdentities() {
+    identitiesLoading = true;
+    try {
+      const { data, error } = await supabase.auth.getUserIdentities();
+      if (error) throw error;
+      identities = data?.identities ?? [];
+    } catch (error) {
+      console.error('Failed to load identities:', error);
+      identities = [];
+    } finally {
+      identitiesLoading = false;
+    }
+  }
+
+  async function linkDiscord() {
+    if (isLinking) return;
+    isLinking = true;
+    try {
+      const { error } = await supabase.auth.linkIdentity({
+        provider: 'discord',
+        options: { redirectTo: `${window.location.origin}/profile` }
+      });
+      if (error) throw error;
+      // The browser is about to navigate away to Discord.
+    } catch (error) {
+      console.error('Discord link failed:', error);
+      toast.error(error?.message || 'Could not start Discord linking. Please try again.');
+      isLinking = false;
+    }
+  }
+
+  async function unlinkDiscord() {
+    if (!discordIdentity || isUnlinking) return;
+
+    const confirmed = await showConfirm(
+      'You will no longer be able to sign in with Discord. Your points, email login, and profile are unaffected.',
+      'Unlink Discord?'
+    );
+    if (!confirmed) return;
+
+    isUnlinking = true;
+    try {
+      const { error } = await supabase.auth.unlinkIdentity(discordIdentity);
+      if (error) throw error;
+      toast.success('Discord unlinked');
+      await loadIdentities();
+    } catch (error) {
+      console.error('Discord unlink failed:', error);
+      toast.error(error?.message || 'Failed to unlink Discord. Please try again.');
+    } finally {
+      isUnlinking = false;
+    }
+  }
+
+  // Returning from a failed OAuth link, Supabase reports the problem in the
+  // URL hash (e.g. "Identity is already linked to another user").
+  function surfaceOAuthError() {
+    const hash = new URLSearchParams(window.location.hash.slice(1));
+    const description = hash.get('error_description');
+    if (!description) return;
+    const friendly = /already linked/i.test(description)
+      ? 'That Discord account is already linked to another member. Contact an officer if you think this is a mistake.'
+      : description;
+    toast.error(friendly, { duration: 8000 });
+    // Clear the error from the URL so refresh doesn't re-toast it.
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
+
   onMount(() => {
     // Setup tab focus handling
     const cleanup = setupEventHandlers();
     cleanupFunctions.push(cleanup);
+
+    surfaceOAuthError();
+    loadIdentities();
   });
 
   onDestroy(() => {
@@ -297,6 +386,61 @@
           {/if}
         </div>
       </Card>
+
+      <!-- Linked sign-in methods (#50) -->
+      <Card class="info-section">
+        <h3>
+          <Link2 size={20} strokeWidth={2} class="icon-inline-lg" />
+          Linked Accounts
+        </h3>
+
+        {#if identitiesLoading}
+          <p class="linked-hint">Loading sign-in methods...</p>
+        {:else}
+          <div class="identity-list">
+            {#each identities as identity (identity.identity_id ?? identity.id)}
+              <div class="identity-row">
+                <div class="identity-info">
+                  {#if identity.provider === 'discord'}
+                    <span class="identity-provider discord">Discord</span>
+                    <span class="identity-detail">{discordDisplayName(identity)}</span>
+                  {:else}
+                    <span class="identity-provider">
+                      <Mail size={14} strokeWidth={2} class="icon-inline" />
+                      Email
+                    </span>
+                    <span class="identity-detail">{identity.identity_data?.email || profile.email}</span>
+                  {/if}
+                </div>
+                {#if identity.provider === 'discord' && canUnlink}
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    subtle
+                    disabled={isUnlinking}
+                    on:click={unlinkDiscord}
+                  >
+                    <Unlink size={14} strokeWidth={2} />
+                    {isUnlinking ? 'Unlinking...' : 'Unlink'}
+                  </Button>
+                {/if}
+              </div>
+            {/each}
+          </div>
+
+          {#if !discordIdentity}
+            <div class="link-discord-block">
+              <Button variant="primary" disabled={isLinking} on:click={linkDiscord}>
+                <Link2 size={16} strokeWidth={2} />
+                {isLinking ? 'Redirecting to Discord...' : 'Link Discord'}
+              </Button>
+              <p class="linked-hint">
+                Linking lets you sign in with Discord. It doesn't change your email, name, or points.
+              </p>
+            </div>
+          {/if}
+        {/if}
+      </Card>
     </div>
   {:else}
     <EmptyState
@@ -429,6 +573,61 @@
 
   .status-active {
     color: var(--color-success);
+  }
+
+  /* Linked accounts */
+  .identity-list {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .identity-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-4);
+    padding: var(--space-3) 0;
+    border-bottom: 1px solid var(--color-border-secondary);
+  }
+
+  .identity-row:last-child {
+    border-bottom: none;
+  }
+
+  .identity-info {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+  }
+
+  .identity-provider {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+    min-width: 80px;
+  }
+
+  .identity-provider.discord {
+    color: #5865f2;
+  }
+
+  .identity-detail {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    word-break: break-all;
+  }
+
+  .link-discord-block {
+    margin-top: var(--space-4);
+  }
+
+  .linked-hint {
+    margin: var(--space-2) 0 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
   }
 
 

--- a/supabase/migrations/20260709152938_handle_new_user_discord_names.sql
+++ b/supabase/migrations/20260709152938_handle_new_user_discord_names.sql
@@ -1,0 +1,23 @@
+-- #50: Discord signups don't always populate full_name in user metadata.
+-- Fall back through the names Discord does provide before defaulting to
+-- the email address.
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+as $function$
+begin
+  insert into public.members (id, email, name)
+  values (
+    new.id,
+    new.email,
+    coalesce(
+      new.raw_user_meta_data->>'full_name',
+      new.raw_user_meta_data->>'name',
+      new.raw_user_meta_data->>'preferred_username',
+      new.email
+    )
+  );
+  return new;
+end;
+$function$;


### PR DESCRIPTION
## Summary
Implements the approved plan for #50: Discord as a second auth provider, with **strictly opt-in** identity linking so existing members keep one account.

### Login (`AuthForm.svelte`)
"Continue with Discord" on the sign-in and sign-up views (Discord blurple, `or` divider). Uses `signInWithOAuth` with the client's existing **implicit flow** — tokens return to `/login` in the URL hash and ride the same `detectSessionInUrl` + `onAuthStateChange` path magic links already use. No client config change, no server callback route. (PKCE was deliberately not adopted: it breaks magic links opened on a different device.)

### Profile — Linked Accounts card
- Lists identities from `getUserIdentities()` (Email → address, Discord → display name from identity metadata)
- **Link Discord** → `linkIdentity` with redirect back to `/profile`, plus copy making the contract explicit: *"Linking lets you sign in with Discord. It doesn't change your email, name, or points."*
- **Unlink** behind the app's `ConfirmDialog`; hidden when Discord is the only identity (Supabase would reject it — no dead button)
- OAuth errors returned in the URL hash surface as toasts; *"identity already linked to another user"* gets a friendly "contact an officer" message, and the hash is cleared so refresh doesn't re-toast
- `members.email` is never touched by linking (denormalized by design)

### New-user provisioning (migration `20260709152938`, **already applied live**)
`handle_new_user` name fallback widened to `full_name → name → preferred_username → email` so Discord-created members get a real name. Committed to `supabase/migrations/` per the established workflow.

## Behavior decisions (from planning)
- **Opt-in linking** is the primary flow for existing members (the owner's core requirement)
- Discord is also a **full signup path** (owner's call — consistent with open email signup); Supabase auto-links when the verified Discord email matches an existing account, so duplicates only arise on email mismatch
- Account-merge tooling stays out of scope until a real duplicate appears (per issue)

## ⚙️ Required before the button works (owner, ~10 min)
1. **Discord Developer Portal**: new application → OAuth2 → redirect `https://ftdradvuyhumgrjrsmkp.supabase.co/auth/v1/callback`, scopes `identify email`
2. **Supabase → Authentication → Providers → Discord**: enable, paste Client ID + Secret
3. **Supabase → Authentication → URL Configuration**: add `https://www.jaxmemberportal.org/*` and `http://localhost:5173/*` to Redirect URLs
4. **Supabase → Authentication → Settings**: enable **Manual Linking**

Until then the buttons render and clicking surfaces Supabase's "provider is not enabled" error as a toast.

## Verification
- `npm run check` 0 errors; production build renders "Continue with Discord" on `/login` (SSR-verified); landing page and login flows unaffected
- Full E2E (link → sign out → Discord sign-in lands in same account with points intact → unlink → email login still works; fresh Discord signup creates a named member with `role='member'`) needs the dashboard setup + a real Discord account — checklist above

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)