### PR TITLE
fix(errors): guard against user-visible 500s + leaderboard true-01-01 400

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -42,3 +42,16 @@ export async function handle({ event, resolve }) {
 
   return response;
 }
+
+/**
+ * Last-resort handler for uncaught errors during SSR (#118). SvelteKit renders
+ * src/routes/+error.svelte with the shape returned here, so the user gets the
+ * branded "something went wrong" page instead of a raw 500. The real error is
+ * logged server-side; only a safe, generic message is exposed to the client.
+ */
+export function handleError({ error, event }) {
+  console.error(`[SSR error] ${event?.url?.pathname ?? ''}`, error);
+  return {
+    message: 'An unexpected error occurred. Please try again.'
+  };
+}

--- a/src/lib/stores/leaderboardStore.js
+++ b/src/lib/stores/leaderboardStore.js
@@ -31,6 +31,13 @@ export async function loadAvailableYears() {
 }
 
 export async function loadLeaderboard(year, force = false) {
+  // Guard: only a real 4-digit-ish year may reach the date range. Callers that
+  // fumble the (year, force) signature — e.g. loadLeaderboard(true) — would
+  // otherwise build `event_date >= "true-01-01"` and 400 against Postgres (#117).
+  if (!Number.isInteger(year) || year < 1970) {
+    year = new Date().getFullYear();
+  }
+
   const cached = cache.get(year);
   if (!force && cached && Date.now() - cached.loadedAt < CACHE_MS) {
     leaderboard.set(cached.data);

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { browser } from '$app/environment';
+import { createRetryFetch } from '$lib/utils/retryFetch';
 
 // Get environment variables
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
@@ -31,6 +32,9 @@ class NoopWebSocket {
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   ...(browser ? {} : { realtime: { transport: NoopWebSocket } }),
+  // Retry transient upstream 5xx/network blips on idempotent requests so a
+  // one-off auth/DB timeout never surfaces to the user (#118).
+  global: { fetch: createRetryFetch() },
   auth: {
     persistSession: true,
     autoRefreshToken: true,

--- a/src/lib/utils/retryFetch.js
+++ b/src/lib/utils/retryFetch.js
@@ -1,0 +1,63 @@
+// Bounded retry wrapper for transient upstream failures (5xx + network errors).
+//
+// Motivation (#118): a one-off GoTrue -> Postgres timeout returned a 500 on
+// `POST /auth/v1/token?grant_type=refresh_token`; the very next call succeeded.
+// A single backoff retry makes that whole class of transient blip invisible to
+// the user instead of surfacing as an auth error.
+//
+// Only *idempotent* requests are retried: GET/HEAD reads, and the Supabase auth
+// token endpoint (login / refresh), which is safe to repeat. Writes to PostgREST
+// (POST/PATCH/PUT/DELETE) are never auto-retried — retrying a write that already
+// partially applied is unsafe, and RLS-denied writes return 0 rows without an
+// error, so a repeat could mask or double an effect.
+
+const MAX_RETRIES = 2; // total attempts = 3
+const BASE_DELAY_MS = 200;
+const MAX_DELAY_MS = 1500;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isRetryable(url, method) {
+  const m = (method || 'GET').toUpperCase();
+  if (m === 'GET' || m === 'HEAD') return true;
+  // Auth token grant/refresh is safe to retry.
+  if (m === 'POST' && /\/auth\/v1\/token\b/.test(url)) return true;
+  return false;
+}
+
+function backoffDelay(attempt) {
+  const base = Math.min(BASE_DELAY_MS * 2 ** attempt, MAX_DELAY_MS);
+  return base + Math.random() * base * 0.25; // +0-25% jitter
+}
+
+/**
+ * Wraps a fetch implementation with retry-on-transient-failure. Pass the result
+ * as the Supabase client's `global.fetch`.
+ */
+export function createRetryFetch(baseFetch = fetch) {
+  return async function retryFetch(input, init = {}) {
+    const url = typeof input === 'string' ? input : input.url;
+    const method = init.method || (typeof input === 'object' ? input.method : 'GET');
+    const retryable = isRetryable(url, method);
+
+    for (let attempt = 0; ; attempt++) {
+      try {
+        const response = await baseFetch(input, init);
+        // Retry only transient server errors, and only while attempts remain.
+        if (retryable && response.status >= 500 && attempt < MAX_RETRIES) {
+          await sleep(backoffDelay(attempt));
+          continue;
+        }
+        return response;
+      } catch (err) {
+        // Network/abort failure — retry if idempotent and attempts remain,
+        // otherwise propagate so the caller can handle it.
+        if (retryable && attempt < MAX_RETRIES) {
+          await sleep(backoffDelay(attempt));
+          continue;
+        }
+        throw err;
+      }
+    }
+  };
+}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,118 @@
+<script>
+  import { page } from '$app/stores';
+
+  // 404 gets its own copy; everything else is treated as a transient failure
+  // with a retry, so an unexpected error never shows a raw stack/500 (#118).
+  $: status = $page.status;
+  $: isNotFound = status === 404;
+
+  function retry() {
+    location.reload();
+  }
+</script>
+
+<svelte:head>
+  <title>{isNotFound ? 'Page not found' : 'Something went wrong'}</title>
+</svelte:head>
+
+<div class="error-page">
+  <div class="error-card">
+    <p class="error-status">{status}</p>
+    <h1 class="error-title">
+      {isNotFound ? 'Page not found' : 'Something went wrong'}
+    </h1>
+    <p class="error-message">
+      {#if isNotFound}
+        We couldn't find the page you were looking for.
+      {:else}
+        This is usually temporary. Please try again in a moment.
+      {/if}
+    </p>
+    <div class="error-actions">
+      {#if !isNotFound}
+        <button type="button" class="btn-primary" on:click={retry}>Try again</button>
+      {/if}
+      <a class="btn-secondary" href="/">Go to home</a>
+    </div>
+  </div>
+</div>
+
+<style>
+  .error-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 70vh;
+    padding: var(--space-6);
+  }
+
+  .error-card {
+    width: 100%;
+    max-width: 28rem;
+    text-align: center;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border-primary);
+    border-radius: var(--radius-card);
+    box-shadow: var(--shadow-card);
+    padding: var(--space-10) var(--space-8);
+  }
+
+  .error-status {
+    font-family: var(--font-family-display);
+    font-size: var(--font-size-5xl);
+    line-height: 1;
+    color: var(--color-brand-primary);
+    margin: 0;
+  }
+
+  .error-title {
+    font-family: var(--font-family-display);
+    font-size: var(--font-size-2xl);
+    color: var(--color-text-primary);
+    margin: var(--space-4) 0 var(--space-2);
+  }
+
+  .error-message {
+    font-family: var(--font-family-base);
+    font-size: var(--font-size-base);
+    color: var(--color-text-secondary);
+    margin: 0 0 var(--space-8);
+  }
+
+  .error-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    justify-content: center;
+  }
+
+  .btn-primary,
+  .btn-secondary {
+    font-family: var(--font-family-base);
+    font-size: var(--font-size-base);
+    padding: var(--space-3) var(--space-6);
+    border-radius: var(--radius-button);
+    cursor: pointer;
+    text-decoration: none;
+    border: 1px solid transparent;
+  }
+
+  .btn-primary {
+    background: var(--color-brand-primary);
+    color: var(--color-text-inverse);
+  }
+
+  .btn-primary:hover {
+    background: var(--color-brand-primary-hover);
+  }
+
+  .btn-secondary {
+    background: transparent;
+    color: var(--color-text-primary);
+    border-color: var(--color-border-primary);
+  }
+
+  .btn-secondary:hover {
+    background: var(--color-bg-secondary);
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,7 +19,7 @@
   $: if ($page.url.pathname === '/' && $authUser?.id) {
     loadApprovals(true);
     loadCategoryData(true);
-    loadLeaderboard(true);
+    loadLeaderboard(new Date().getFullYear(), true);
     loadUserProfile(true).catch((err) => console.error('Failed to load profile:', err));
     loadCompetitionData(true);
     loadMyEntries(true);

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -50,7 +50,7 @@
       await Promise.all([
         loadApprovals(true),
         loadCategoryData(true),
-        loadLeaderboard(true), // Fixed typo: was loadleaderboardData
+        loadLeaderboard(new Date().getFullYear(), true),
         loadMySubmissions(true)
       ]);
     } catch (error) {


### PR DESCRIPTION
## Summary

Two related error-hygiene fixes, found while investigating a transient auth 500 in the Supabase logs.

### 1. Never show a raw 500 for a transient blip (#118)
A user hit `POST /auth/v1/token?grant_type=refresh_token → 500` ("error finding user: timeout: context canceled"); the next call succeeded ~1s later. Correlated Postgres logs showed a canceled statement / broken pipe — a one-off GoTrue→DB timeout.

- **`retryFetch`** wraps the Supabase client's `global.fetch` with bounded exponential backoff + jitter (3 attempts) for `5xx`/network errors, **only on idempotent requests** — GET/HEAD reads and the auth token endpoint. Writes (POST/PATCH/DELETE to PostgREST) are **never** auto-retried, so a partially-applied or RLS-denied write is never repeated.
- **Global error boundary**: new `src/routes/+error.svelte` (branded "try again" page) + `handleError` in `hooks.server.js`, so any uncaught client/SSR error renders a friendly page instead of a raw 500. The repo had neither before.

### 2. Leaderboard `true-01-01` 400 (#117)
The home and login pages called `loadLeaderboard(true)`, but the signature is `loadLeaderboard(year, force)` — so `year` became the boolean `true` and the query built `event_date >= "true-01-01"`, 400ing on nearly every logged-in home/login load.

- Fixed both callers to `loadLeaderboard(new Date().getFullYear(), true)`.
- Added a guard in `loadLeaderboard` so a non-year arg can never reach Postgres again.

## Verification
- `svelte-check`: 0 errors
- `lint:inline` and `lint:css`: clean (no new warnings; `+error.svelte` uses design-system tokens only)
- Production build (`adapter-node`): green
- Mock-fetch harness exercises the retry logic — 5/5: auth 500→200 retried, GET persistent 500 returns after 3 attempts, **write 500 not retried**, GET network-error retried, 4xx not retried.

Closes #117
Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)