### PR TITLE
feat(profile): show Discord avatar in the profile header when linked (#50)

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -167,6 +167,12 @@
   // (covers Discord-created accounts that have no email identity).
   $: canUnlink = discordIdentity && identities.length > 1;
 
+  // Discord avatar for the profile header; falls back to the generic icon
+  // if none is linked or the CDN image fails to load.
+  let avatarFailed = false;
+  $: discordAvatarUrl = discordIdentity?.identity_data?.avatar_url ?? null;
+  $: if (discordAvatarUrl) avatarFailed = false;
+
   function discordDisplayName(identity) {
     const d = identity?.identity_data ?? {};
     return d.custom_claims?.global_name || d.full_name || d.name || d.email || 'Discord account';
@@ -273,7 +279,17 @@
       <!-- Profile Header -->
       <Card class="profile-header">
         <div class="avatar">
-          <UserIcon size={40} strokeWidth={2} color="white" />
+          {#if discordAvatarUrl && !avatarFailed}
+            <img
+              class="avatar-img"
+              src={discordAvatarUrl}
+              alt="Discord avatar for {profile.name || 'member'}"
+              referrerpolicy="no-referrer"
+              on:error={() => (avatarFailed = true)}
+            />
+          {:else}
+            <UserIcon size={40} strokeWidth={2} color="white" />
+          {/if}
         </div>
         <div class="header-info">
           <h2>{profile.name || 'Member'}</h2>
@@ -477,6 +493,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    overflow: hidden;
     flex-shrink: 0;
   }
 
@@ -573,6 +590,13 @@
 
   .status-active {
     color: var(--color-success);
+  }
+
+  .avatar-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
   }
 
   /* Linked accounts */

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -11,6 +11,7 @@ export default {
     // - fonts.googleapis.com / fonts.gstatic.com: the DM Sans + Oswald fonts
     //   loaded from app.html.
     // - *.supabase.co: auth + PostgREST (https) and realtime (wss).
+    // - cdn.discordapp.com: Discord avatars for linked accounts (#50).
     csp: {
       mode: 'auto',
       directives: {
@@ -18,7 +19,7 @@ export default {
         'script-src': ['self'],
         'style-src': ['self', 'unsafe-inline', 'https://fonts.googleapis.com'],
         'font-src': ['self', 'data:', 'https://fonts.gstatic.com'],
-        'img-src': ['self', 'data:', 'blob:'],
+        'img-src': ['self', 'data:', 'blob:', 'https://cdn.discordapp.com'],
         'connect-src': ['self', 'https://*.supabase.co', 'wss://*.supabase.co'],
         'worker-src': ['self'],
         'manifest-src': ['self'],


### PR DESCRIPTION
## Summary
Follow-up to #119: when a member has linked Discord, the My Profile header shows their **Discord profile picture** instead of the generic user icon.

- Avatar comes from the linked Discord identity's `identity_data.avatar_url` (already fetched by the page's `getUserIdentities()` call — no new requests)
- Graceful fallback to the generic icon when nothing is linked, the identity has no avatar, or the CDN image fails to load (`on:error`)
- `referrerpolicy="no-referrer"` on the image; `.avatar` gains `overflow: hidden` so the image clips to the existing circle
- **CSP**: `img-src` gains `https://cdn.discordapp.com` (avatars are served from Discord's CDN; the previous policy blocked it) — verified in the response header on the production build

Unlinking Discord naturally reverts the header to the generic icon on next load, keeping with the opt-in contract.

## Verification
- `npm run check` 0 errors; production build serves `img-src 'self' data: blob: https://cdn.discordapp.com`
- Rendering with a real linked avatar needs a Discord-linked account (same E2E checklist as #119 — dashboard setup pending)

Refs #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)