### PR TITLE
fix(push): prevent endpoint ownership reassignment + auth debugging docs (#58, #124)

### DIFF
--- a/docs/auth-debugging.md
+++ b/docs/auth-debugging.md
@@ -1,0 +1,53 @@
+# Auth debugging: where login events actually live
+
+Notes from the #50 Discord identity-linking verification (2026-07-10). See issue #124.
+
+## TL;DR
+
+| Signal | Maintained? | Use for |
+|---|---|---|
+| `auth.audit_log_entries` | ✅ every auth event, with provider | **Source of truth** for logins, logouts, signups, token refreshes |
+| `auth.users.last_sign_in_at` | ✅ on every sign-in | "When did this user last authenticate" (no provider attribution) |
+| `public.members.last_login_at` | ✅ app-maintained | Portal-level last login (updated by the root layout ~2s after sign-in) |
+| `auth.identities.last_sign_in_at` | ❌ **never updated after creation** | Nothing — do not trust it |
+
+## The trap
+
+`auth.identities.last_sign_in_at` looks like "when was this identity last used to sign in." It is not. GoTrue sets it at identity creation and never touches it again:
+
+- A long-standing email identity on an active account showed `last_sign_in_at = 2025-05-21` (its creation time) despite daily email logins since, including one the same morning it was checked.
+- A freshly linked Discord identity kept `last_sign_in_at == created_at` even after two successful Discord sign-ins minutes later.
+
+Any query like "which members actually use Discord to sign in" built on this column silently reports garbage.
+
+## The source of truth
+
+```sql
+select created_at,
+       payload->>'action' as action,
+       payload->>'actor_username' as actor,
+       coalesce(payload->'traits'->>'provider', payload->>'provider') as provider
+from auth.audit_log_entries
+where payload->>'actor_id' = '<auth user uuid>'   -- omit for all users
+order by created_at desc
+limit 50;
+```
+
+Actions observed in this project: `login` (with `provider: email | discord`), `logout`, `token_refreshed`, `token_revoked`, `user_signedup`, `user_recovery_requested`.
+
+### Example: Discord adoption report
+
+```sql
+select date_trunc('day', created_at) as day, count(*) as discord_logins,
+       count(distinct payload->>'actor_id') as distinct_members
+from auth.audit_log_entries
+where payload->>'action' = 'login'
+  and coalesce(payload->'traits'->>'provider', payload->>'provider') = 'discord'
+group by 1 order by 1 desc;
+```
+
+## Caveats
+
+- **Retention**: hosted Supabase prunes `audit_log_entries` (retention depends on plan). Long-range reporting needs periodic snapshots into an app table.
+- The audit log is in the `auth` schema — query it via the Supabase SQL editor or a service-role connection, never from the client.
+- Identity *existence* (is Discord linked?) is fine to read from `auth.identities` / `getUserIdentities()` — it's only the `last_sign_in_at` column that lies.

--- a/src/routes/api/push/subscribe/+server.js
+++ b/src/routes/api/push/subscribe/+server.js
@@ -31,6 +31,26 @@ export async function POST({ request }) {
     throw error(400, 'Missing subscription');
   }
 
+  // This route runs with the service role (RLS bypassed), so ownership must
+  // be enforced here: without this check, the endpoint-keyed upsert would
+  // let any authenticated caller who knows another member's endpoint URL
+  // reassign that row to themselves (#58). Endpoints are unguessable
+  // capability URLs, so a conflicting owner means a replayed/stolen value —
+  // reject rather than transfer.
+  const { data: existing, error: lookupError } = await supabaseAdmin
+    .from('push_subscriptions')
+    .select('member_id')
+    .eq('endpoint', subscription.endpoint)
+    .maybeSingle();
+
+  if (lookupError) {
+    console.error('Error checking push subscription owner:', lookupError);
+    throw error(500, 'Failed to save subscription');
+  }
+  if (existing && existing.member_id !== user.id) {
+    throw error(409, 'This device is registered to another account');
+  }
+
   // Always use the authenticated user's ID — never trust memberId from the request body
   const { error: dbError } = await supabaseAdmin
     .from('push_subscriptions')


### PR DESCRIPTION
## Summary

### #58 — push endpoint ownership
The subscribe route runs with the **service role** (RLS bypassed), so its `upsert(..., { onConflict: 'endpoint' })` let any authenticated caller who knew another member's endpoint URL silently take ownership of that row. The handler now checks the existing row's owner first and returns **409 "This device is registered to another account"** on a mismatch. Rationale for reject-over-transfer: push endpoints are unguessable capability URLs, so a conflicting owner means a replayed/stolen value, not a legitimate shared device. (Residual check-then-act race collapses to the current behavior at worst; severity is theoretical per the issue.)

Re-subscribes by the same member (endpoint refresh, #74 rotation re-sync) hit the same-owner path and upsert exactly as before.

### #124 — `docs/auth-debugging.md`
The GoTrue login-signal findings from the #50 verification, written down: `auth.identities.last_sign_in_at` is never updated after identity creation (evidence included); `auth.audit_log_entries` is the source of truth, with the provider-extraction query, a Discord-adoption report recipe, and retention caveats.

## Verification
- `npm run check` 0 errors; production build serves the endpoint (500 locally at the env-var guard, same as prod today — the auth/ownership paths become reachable once the push secrets exist)
- Ownership logic is exercised in prod the moment `SUPABASE_SERVICE_ROLE_KEY` is set (see push hookup notes on the thread)

Closes #58
Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)