### PR TITLE
fix(push): runtime env name + browser-subscription rollback (#127)

### DIFF
--- a/src/lib/components/NotificationPermission.svelte
+++ b/src/lib/components/NotificationPermission.svelte
@@ -110,7 +110,12 @@
         body: JSON.stringify({ subscription })
       });
 
-      if (!response.ok) throw new Error('Failed to save subscription');
+      if (!response.ok) {
+        // Roll the browser subscription back, or the bell reads as enabled
+        // on the next launch while the server has no row (#127).
+        await subscription.unsubscribe().catch(() => {});
+        throw new Error('Failed to save subscription');
+      }
 
       if (session?.user) {
         localStorage.setItem(SYNC_MARKER_KEY, `${session.user.id}|${subscription.endpoint}`);

--- a/src/routes/api/push/send/+server.js
+++ b/src/routes/api/push/send/+server.js
@@ -4,7 +4,8 @@ import webpush from 'web-push';
 
 /** @type {import('./$types').RequestHandler} */
 export async function POST({ request }) {
-  const supabaseUrl = process.env.VITE_SUPABASE_URL;
+  // Cloud Run injects SUPABASE_URL; VITE_SUPABASE_URL is builder-stage only (#127).
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   const vapidPublicKey = process.env.VITE_VAPID_PUBLIC_KEY;
   const vapidPrivateKey = process.env.VAPID_PRIVATE_KEY;

--- a/src/routes/api/push/subscribe/+server.js
+++ b/src/routes/api/push/subscribe/+server.js
@@ -3,7 +3,10 @@ import { createClient } from '@supabase/supabase-js';
 
 /** @type {import('./$types').RequestHandler} */
 export async function POST({ request }) {
-  const supabaseUrl = process.env.VITE_SUPABASE_URL;
+  // Runtime env names vary: Cloud Run injects SUPABASE_URL; the VITE_ name
+  // only exists in the Docker *builder* stage, never at runtime (#127).
+  // Same dual-name handling as /api/calendar.
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!supabaseUrl || !serviceRoleKey) {
@@ -73,7 +76,7 @@ export async function POST({ request }) {
 
 /** @type {import('./$types').RequestHandler} */
 export async function DELETE({ request }) {
-  const supabaseUrl = process.env.VITE_SUPABASE_URL;
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!supabaseUrl || !serviceRoleKey) {


### PR DESCRIPTION
## Summary
Fixes both bugs from #127:

**Server (the 500):** all three push handlers read `process.env.VITE_SUPABASE_URL`, which only exists in the Docker *builder* stage — the runtime container gets `SUPABASE_URL` from Cloud Run. Every push request died at the env guard with an unlogged 500 (hence the bare 500s in the logs). Handlers now accept either name, same as `/api/calendar`.

**Client (the lying bell):** `pushManager.subscribe()` succeeded before the server save failed, and nothing rolled it back — so on relaunch the bell read browser state and showed enabled while `push_subscriptions` stayed empty. A failed save now unsubscribes the browser subscription before surfacing the error toast.

## Verification
Production build run under **prod-identical env** (`SUPABASE_URL` set, no `VITE_SUPABASE_URL`, service-role + VAPID vars present):

| Endpoint | Before | After |
|---|---|---|
| `POST /api/push/subscribe` (no auth) | 500 "Server misconfigured" | **401 Unauthorized** |
| `DELETE /api/push/subscribe` | 500 | **401** |
| `POST /api/push/send` | 500 | **401** |

`npm run check` 0 errors.

**Post-merge test (needs a real session):** click the bell → expect the success toast this time → confirm a row lands in `push_subscriptions` → officer send from `/officers/notifications`. Your existing browser subscription from the failed attempts will re-sync automatically on first launch (#74 path). Note the service-role key in secrets is the new `sb_secret_…` format — the first real subscribe will confirm GoTrue accepts it.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)