### PR TITLE
feat(push): in-app popup for tapped notifications + officer deep-link field (#130)

### DIFF
--- a/src/lib/components/NotificationPopup.svelte
+++ b/src/lib/components/NotificationPopup.svelte
@@ -1,0 +1,182 @@
+<script>
+  import { onMount } from 'svelte';
+  import { Bell } from 'lucide-svelte';
+
+  /**
+   * In-app display of a tapped push notification (#130). The service worker
+   * hands the notification content off via ?pn=1&pn_title=&pn_body= query
+   * params -- the only channel that survives a cold start. Mounted by the
+   * root layout ABOVE the logged-out landing gate so the message shows even
+   * before the session restores.
+   */
+  let open = false;
+  let title = '';
+  let body = '';
+
+  onMount(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('pn') !== '1') return;
+
+    // Cap at the server-side send limits; anything longer is not ours.
+    title = (params.get('pn_title') || '').slice(0, 100);
+    body = (params.get('pn_body') || '').slice(0, 200);
+
+    stripParams();
+    if (title || body) open = true;
+  });
+
+  // Remove the pn_* params so refresh/back-forward doesn't re-show the popup.
+  function stripParams() {
+    const url = new URL(window.location.href);
+    for (const key of ['pn', 'pn_title', 'pn_body']) {
+      url.searchParams.delete(key);
+    }
+    history.replaceState(null, '', url.pathname + url.search + url.hash);
+  }
+
+  function dismiss() {
+    open = false;
+  }
+
+  function handleKeydown(e) {
+    if (!open) return;
+    if (e.key === 'Escape' || e.key === 'Enter') dismiss();
+  }
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+{#if open}
+  <div
+    class="backdrop"
+    role="presentation"
+    on:click={(e) => e.target === e.currentTarget && dismiss()}
+    on:keydown={handleKeydown}
+  >
+    <div
+      class="dialog"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="pn-title"
+      aria-describedby="pn-message"
+    >
+      <div class="dialog-header">
+        <span class="dialog-icon">
+          <Bell size={20} strokeWidth={2} />
+        </span>
+        <h2 id="pn-title" class="dialog-title">{title || 'Notification'}</h2>
+      </div>
+      {#if body}
+        <div class="dialog-body">
+          <p id="pn-message" class="dialog-message">{body}</p>
+        </div>
+      {/if}
+      <div class="dialog-footer">
+        <button class="btn btn-ok" on:click={dismiss}>OK</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-4);
+    z-index: 10000;
+    animation: fadeIn 0.15s ease;
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+
+  .dialog {
+    background: var(--color-bg-primary);
+    border-radius: var(--radius-lg, 10px);
+    border-top: 3px solid var(--color-brand-gold);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    width: 100%;
+    max-width: 420px;
+    animation: slideUp 0.15s ease;
+  }
+
+  @keyframes slideUp {
+    from { transform: translateY(16px); opacity: 0; }
+    to   { transform: translateY(0);    opacity: 1; }
+  }
+
+  .dialog-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-5) var(--space-6) var(--space-2);
+  }
+
+  .dialog-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--color-brand-primary);
+    color: var(--color-brand-gold);
+    flex-shrink: 0;
+  }
+
+  .dialog-title {
+    font-family: var(--font-family-display, 'Oswald', sans-serif);
+    font-size: var(--font-size-lg, 1.125rem);
+    font-weight: 600;
+    color: var(--color-text-primary);
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    overflow-wrap: anywhere;
+  }
+
+  .dialog-body {
+    padding: var(--space-3) var(--space-6) var(--space-5);
+  }
+
+  .dialog-message {
+    font-size: var(--font-size-base, 1rem);
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+    margin: 0;
+    overflow-wrap: anywhere;
+    white-space: pre-line;
+  }
+
+  .dialog-footer {
+    display: flex;
+    justify-content: flex-end;
+    padding: var(--space-4) var(--space-6);
+    border-top: 1px solid var(--color-border-primary, var(--color-gray-200));
+  }
+
+  .btn-ok {
+    padding: var(--space-2) var(--space-6);
+    border-radius: var(--radius-button, 6px);
+    font-family: var(--font-family-display, 'Oswald', sans-serif);
+    font-size: var(--font-size-sm, 0.875rem);
+    font-weight: 600;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    border: none;
+    background: var(--color-brand-primary);
+    color: var(--color-white);
+  }
+
+  .btn-ok:hover {
+    background: var(--color-brand-primary-dark, var(--color-brand-primary-hover));
+  }
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
   import NotificationPermission from '$lib/components/NotificationPermission.svelte';
   import InstallPrompt from '$lib/components/InstallPrompt.svelte';
   import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+  import NotificationPopup from '$lib/components/NotificationPopup.svelte';
   import LandingPage from '$lib/components/LandingPage.svelte';
 
   let subscription;
@@ -182,6 +183,9 @@
 />
 <InstallPrompt />
 <ConfirmDialog />
+<!-- Above the landing gate on purpose: a tapped notification must display
+     even before the session restores (#130). -->
+<NotificationPopup />
 
 <!-- Logged-out visitors get the landing page instead of app pages (#97):
      with RLS the anon role reads no data, so app pages would only render

--- a/src/routes/officers/notifications/+page.svelte
+++ b/src/routes/officers/notifications/+page.svelte
@@ -8,9 +8,27 @@
 
   let title = '';
   let message = '';
+  let linkUrl = '';
   let isSending = false;
   let subscriberCount = null;
   let lastResult = null;
+
+  /**
+   * Validate the optional deep-link: same-origin relative paths only,
+   * mirroring the server-side check in /api/push/send (#130). Returns the
+   * normalized path, or null when the input is invalid/external.
+   */
+  function validateLink(value) {
+    const trimmed = value.trim();
+    if (!trimmed) return '/';
+    try {
+      const parsed = new URL(trimmed, window.location.origin);
+      if (parsed.origin !== window.location.origin) return null;
+      return parsed.pathname + parsed.search + parsed.hash;
+    } catch {
+      return null;
+    }
+  }
 
   // Access control is enforced by officers/+layout; officers only reach here.
   onMount(loadSubscriberCount);
@@ -38,6 +56,12 @@
       return;
     }
 
+    const safeUrl = validateLink(linkUrl);
+    if (safeUrl === null) {
+      toast.error('Link must be a page within the portal, e.g. /events');
+      return;
+    }
+
     isSending = true;
     lastResult = null;
 
@@ -50,7 +74,7 @@
           'Content-Type': 'application/json',
           Authorization: `Bearer ${session.access_token}`
         },
-        body: JSON.stringify({ title: title.trim(), message: message.trim(), url: '/' })
+        body: JSON.stringify({ title: title.trim(), message: message.trim(), url: safeUrl })
       });
 
       const result = await response.json();
@@ -64,6 +88,7 @@
 
       title = '';
       message = '';
+      linkUrl = '';
 
       // Refresh count (some may have been removed as expired)
       await loadSubscriberCount();
@@ -140,6 +165,23 @@
             required
           />
           <div class="char-count">{message.length}/200</div>
+        </div>
+
+        <div class="form-group">
+          <label for="notif-link" class="form-label">Link to page <span class="optional">(optional)</span></label>
+          <input
+            id="notif-link"
+            type="text"
+            class="form-control"
+            bind:value={linkUrl}
+            placeholder="/events"
+            maxlength="200"
+            disabled={isSending}
+          />
+          <div class="field-hint">
+            Where tapping the notification takes members. Leave blank for the home page.
+            Portal pages only.
+          </div>
         </div>
 
         {#if lastResult}
@@ -221,6 +263,16 @@
 
   .required {
     color: var(--color-danger);
+  }
+
+  .optional {
+    color: var(--color-text-secondary);
+    font-weight: var(--font-weight-normal);
+  }
+
+  .field-hint {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
   }
 
   .form-control {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -100,6 +100,18 @@ sw.addEventListener('notificationclick', (event) => {
   try {
     const parsed = new URL(rawUrl, sw.location.origin);
     if (parsed.origin === sw.location.origin) {
+      // Hand the notification content to the page as query params so the
+      // app can show it in an in-app popup (#130). Query params are the
+      // only channel that survives a cold start: postMessage races page
+      // boot, and a service worker cannot reach localStorage. The page
+      // strips these with history.replaceState after displaying.
+      parsed.searchParams.set('pn', '1');
+      if (event.notification.title) {
+        parsed.searchParams.set('pn_title', event.notification.title);
+      }
+      if (event.notification.body) {
+        parsed.searchParams.set('pn_body', event.notification.body);
+      }
       url = parsed.pathname + parsed.search + parsed.hash;
     }
   } catch {


### PR DESCRIPTION
## Summary
Implements #130 as planned on the ticket:

**Service worker → page handoff.** `notificationclick` now appends the notification's title/body as `pn`/`pn_title`/`pn_body` query params to the target URL — *after* the existing #83 origin sanitization, which is untouched. Query params are the only channel that survives a cold app start (SW `postMessage` races page boot; localStorage is unreachable from a SW). Works identically for the already-open-window path since `client.navigate()` carries the params.

**`NotificationPopup.svelte`** (new), mounted in the root layout **above the logged-out landing gate** so a tapped notification displays even before the session restores:
- Branded `alertdialog` matching `ConfirmDialog` — bell icon, title, message, single **OK** button
- Dismiss via OK, Escape, Enter, or backdrop click
- Params are stripped with `history.replaceState` immediately on read → refresh/back-forward never re-shows it
- Content rendered as Svelte text nodes (auto-escaped) and capped at the server-side send limits (100/200 chars)

**Officer send form: "Link to page" (optional).** The API always validated a `url` field; the form finally uses it. Blank → `/` (current behavior). Set (e.g. `/events`) → the tap deep-links there *and* shows the popup on that page. Client-side validation mirrors the server: same-origin relative paths only (the `URL`-resolution check also neutralizes `/\evil.com`-style tricks), with the SW's origin check as the final guard.

## Verification
- `npm run check` 0 errors; production build green; built `service-worker.js` contains the handoff logic
- **Manual test after deploy, no push needed:** visit
  `https://www.jaxmemberportal.org/?pn=1&pn_title=Test&pn_body=It%20works`
  → popup appears with OK button; after dismissing, the URL is clean and refresh shows nothing
- Full flow: officer send with a `/events` link → tap the notification → app opens /events with the popup showing the message

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)