### PR TITLE
fix(push): IndexedDB fallback so the notification popup survives cold starts (#130)

### DIFF
--- a/src/lib/components/NotificationPopup.svelte
+++ b/src/lib/components/NotificationPopup.svelte
@@ -1,28 +1,50 @@
 <script>
   import { onMount } from 'svelte';
   import { Bell } from 'lucide-svelte';
+  import { takePendingNotification } from '$lib/utils/pendingNotification.js';
 
   /**
-   * In-app display of a tapped push notification (#130). The service worker
-   * hands the notification content off via ?pn=1&pn_title=&pn_body= query
-   * params -- the only channel that survives a cold start. Mounted by the
-   * root layout ABOVE the logged-out landing gate so the message shows even
-   * before the session restores.
+   * In-app display of a tapped push notification (#130). Two handoff
+   * channels from the service worker, checked in order:
+   * 1. ?pn=1&pn_title=&pn_body= query params (warm windows, manual tests)
+   * 2. IndexedDB fallback -- when the OS launches a fully-closed PWA the
+   *    launch flow can drop the query params, so the SW also parks the
+   *    content there.
+   * Mounted by the root layout ABOVE the logged-out landing gate so the
+   * message shows even before the session restores.
    */
   let open = false;
   let title = '';
   let body = '';
 
-  onMount(() => {
+  // A parked record older than this is from a launch that never finished --
+  // don't pop it up days later.
+  const PENDING_MAX_AGE_MS = 5 * 60 * 1000;
+
+  onMount(async () => {
     const params = new URLSearchParams(window.location.search);
-    if (params.get('pn') !== '1') return;
+    if (params.get('pn') === '1') {
+      // Cap at the server-side send limits; anything longer is not ours.
+      title = (params.get('pn_title') || '').slice(0, 100);
+      body = (params.get('pn_body') || '').slice(0, 200);
+      stripParams();
+      // Consume the IDB copy too so it can't re-show on the next launch.
+      takePendingNotification(0).catch(() => {});
+      if (title || body) open = true;
+      return;
+    }
 
-    // Cap at the server-side send limits; anything longer is not ours.
-    title = (params.get('pn_title') || '').slice(0, 100);
-    body = (params.get('pn_body') || '').slice(0, 200);
-
-    stripParams();
-    if (title || body) open = true;
+    // Cold-start fallback: no params made it through -- check IndexedDB.
+    try {
+      const pending = await takePendingNotification(PENDING_MAX_AGE_MS);
+      if (pending) {
+        title = (pending.title || '').slice(0, 100);
+        body = (pending.body || '').slice(0, 200);
+        if (title || body) open = true;
+      }
+    } catch {
+      // No IDB (private mode, ancient browser) -- nothing to show.
+    }
   });
 
   // Remove the pn_* params so refresh/back-forward doesn't re-show the popup.

--- a/src/lib/utils/pendingNotification.js
+++ b/src/lib/utils/pendingNotification.js
@@ -1,0 +1,68 @@
+/**
+ * IndexedDB parking spot for a tapped push notification (#130 cold-start fix).
+ *
+ * The service worker hands notification content to the page via query params,
+ * but when the OS launches a fully-closed PWA the launch flow can drop them.
+ * IndexedDB is the one storage both contexts share (service workers cannot
+ * touch localStorage), so the SW also parks the content here and the popup
+ * component consumes it as a fallback.
+ *
+ * Plain functions only — imported by both the service worker bundle and
+ * NotificationPopup.svelte.
+ */
+
+const DB_NAME = 'jax-push';
+const STORE = 'pending';
+const KEY = 'last';
+
+function openDb() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => req.result.createObjectStore(STORE);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** @param {{ title: string, body: string, ts: number }} data */
+export async function savePendingNotification(data) {
+  const db = await openDb();
+  try {
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite');
+      tx.objectStore(STORE).put(data, KEY);
+      tx.oncomplete = resolve;
+      tx.onerror = () => reject(tx.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Read AND delete the parked notification. Returns null when there is none
+ * or it is older than maxAgeMs (a stale record from a launch that never
+ * completed must not pop up days later).
+ * @param {number} maxAgeMs
+ */
+export async function takePendingNotification(maxAgeMs) {
+  const db = await openDb();
+  let record;
+  try {
+    record = await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite');
+      const store = tx.objectStore(STORE);
+      const get = store.get(KEY);
+      get.onsuccess = () => {
+        store.delete(KEY);
+        resolve(get.result ?? null);
+      };
+      get.onerror = () => reject(get.error);
+    });
+  } finally {
+    db.close();
+  }
+  if (!record || typeof record.ts !== 'number') return null;
+  if (Date.now() - record.ts > maxAgeMs) return null;
+  return record;
+}

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -4,6 +4,7 @@
 /// <reference lib="webworker" />
 
 import { build, files, version } from '$service-worker';
+import { savePendingNotification } from '$lib/utils/pendingNotification.js';
 
 const sw = /** @type {ServiceWorkerGlobalScope} */ (/** @type {unknown} */ (self));
 
@@ -101,10 +102,11 @@ sw.addEventListener('notificationclick', (event) => {
     const parsed = new URL(rawUrl, sw.location.origin);
     if (parsed.origin === sw.location.origin) {
       // Hand the notification content to the page as query params so the
-      // app can show it in an in-app popup (#130). Query params are the
-      // only channel that survives a cold start: postMessage races page
-      // boot, and a service worker cannot reach localStorage. The page
-      // strips these with history.replaceState after displaying.
+      // app can show it in an in-app popup (#130). The page strips these
+      // with history.replaceState after displaying. NOTE: when the OS
+      // launches a fully-closed PWA these params can be dropped, so the
+      // content is ALSO parked in IndexedDB below — the popup component
+      // falls back to it.
       parsed.searchParams.set('pn', '1');
       if (event.notification.title) {
         parsed.searchParams.set('pn_title', event.notification.title);
@@ -119,8 +121,18 @@ sw.addEventListener('notificationclick', (event) => {
   }
 
   event.waitUntil(
-    sw.clients
-      .matchAll({ type: 'window', includeUncontrolled: true })
+    // Park the content in IndexedDB first (cold-start fallback, #130): the
+    // popup reads-and-deletes it when the URL params don't make it through.
+    // An IDB failure must never block opening the app.
+    savePendingNotification({
+      title: event.notification.title || '',
+      body: event.notification.body || '',
+      ts: Date.now()
+    })
+      .catch(() => {})
+      .then(() =>
+        sw.clients.matchAll({ type: 'window', includeUncontrolled: true })
+      )
       .then((clientList) => {
         for (const client of clientList) {
           if ('focus' in client) {


### PR DESCRIPTION
## Summary
Reproduced edge case: notification tapped while the app is **fully closed** → no popup; app in background → popup works. Cause: the warm path (`client.navigate(url)`) preserves the `pn_*` query params, but when the OS launches a closed PWA the launch flow can drop them — the params-only handoff was insufficient for cold starts.

**Fix — dual-channel handoff:**
- The service worker now **parks the notification content in IndexedDB** (the one storage a SW and the page share; localStorage is unreachable from a SW) *before* opening/focusing the window. An IDB failure never blocks opening the app.
- `NotificationPopup` checks the URL params first (warm windows, manual test URL), then falls back to a **read-and-delete** of the IDB record.
- **5-minute freshness cap**: a parked record from a launch that never completed can't pop up days later.
- The params path also consumes the IDB copy, so nothing ever double-shows; read-and-delete means refresh never re-shows either.

New shared helper `src/lib/utils/pendingNotification.js`, imported by both the SW bundle and the component (verified present in the built `service-worker.js`).

## Verification
- `svelte-check` 0 errors, build green, IDB helper confirmed in the compiled SW
- Manual test URL still works: `/?pn=1&pn_title=Test&pn_body=It%20works`
- The cold-start repro needs the phone: after deploy **and one open/close cycle for the new SW to activate**, force-close the app → send a notification → tap → popup should now appear

Refs #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)