### PR TITLE
feat(push): audience targeting + per-member notification reach (#134, #135)

### DIFF
--- a/src/lib/push/subscriptions.js
+++ b/src/lib/push/subscriptions.js
@@ -1,0 +1,30 @@
+// Shared "who's subscribed" reach data for officer tooling.
+//
+// Both the member roster (#135) and the notification send page (#134) need to
+// know which members receive push notifications. A member can have several
+// subscribed devices, so the source of truth is one row per device in
+// push_subscriptions. Officers may read every row via the
+// "Officers and owners can view push subscriptions" RLS policy (#96), so this
+// is a single aggregate query — never per-member (N+1).
+import { supabase } from '$lib/supabaseClient';
+
+/**
+ * Fetch push-subscription device counts keyed by member_id.
+ *
+ * @returns {Promise<Map<string, number>>} member_id → number of subscribed
+ *   devices. Members with no subscriptions are simply absent from the map.
+ */
+export async function fetchSubscriptionCounts() {
+  const { data, error } = await supabase
+    .from('push_subscriptions')
+    .select('member_id');
+
+  if (error) throw error;
+
+  const counts = new Map();
+  for (const row of data ?? []) {
+    if (!row.member_id) continue; // orphaned rows shouldn't gate reach math
+    counts.set(row.member_id, (counts.get(row.member_id) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/src/routes/api/push/send/+server.js
+++ b/src/routes/api/push/send/+server.js
@@ -40,10 +40,48 @@ export async function POST({ request }) {
   }
 
   const body = await request.json();
-  const { title, message, url } = body;
+  const { title, message, url, audience } = body;
 
   if (!title?.trim() || !message?.trim()) {
     throw error(400, 'Title and message are required');
+  }
+
+  // ---- Audience targeting (#134) ---------------------------------------
+  // The recipient set is computed server-side; a crafted request may only
+  // choose *which* members to target, never the endpoints themselves. Shape:
+  //   { type: 'all' | 'officers' | 'members', memberIds?: uuid[] }
+  // Absent/`all` preserves the original broadcast-to-everyone behavior.
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const MAX_TARGETED_MEMBERS = 50;
+
+  const audienceType = audience?.type ?? 'all';
+  if (!['all', 'officers', 'members'].includes(audienceType)) {
+    throw error(400, 'Invalid audience type');
+  }
+
+  let targetMemberIds = null; // null = no member_id filter (all subscriptions)
+
+  if (audienceType === 'officers') {
+    const { data: officers, error: officerError } = await supabaseAdmin
+      .from('members')
+      .select('id')
+      .eq('is_officer', true);
+    if (officerError) {
+      throw error(500, 'Failed to resolve officer audience');
+    }
+    targetMemberIds = (officers ?? []).map((m) => m.id);
+  } else if (audienceType === 'members') {
+    const ids = audience?.memberIds;
+    if (!Array.isArray(ids) || ids.length === 0) {
+      throw error(400, 'memberIds must be a non-empty array for a targeted send');
+    }
+    if (ids.length > MAX_TARGETED_MEMBERS) {
+      throw error(400, `Cannot target more than ${MAX_TARGETED_MEMBERS} members at once`);
+    }
+    if (!ids.every((id) => typeof id === 'string' && UUID_RE.test(id))) {
+      throw error(400, 'memberIds must all be valid UUIDs');
+    }
+    targetMemberIds = ids;
   }
 
   // Server-side caps mirroring the client form limits — the client's
@@ -73,10 +111,19 @@ export async function POST({ request }) {
 
   webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
 
-  // Fetch all subscriptions
-  const { data: subscriptions, error: fetchError } = await supabaseAdmin
-    .from('push_subscriptions')
-    .select('id, endpoint, subscription');
+  // Fetch subscriptions for the resolved audience. An empty targetMemberIds
+  // (e.g. officers-only with no officers subscribed, or a valid but
+  // unsubscribed member list) means nobody to reach — short-circuit rather
+  // than issuing an `.in(..., [])` that matches everything on some drivers.
+  if (targetMemberIds !== null && targetMemberIds.length === 0) {
+    return json({ ok: true, sent: 0, failed: 0, message: 'No subscribers in audience' });
+  }
+
+  let query = supabaseAdmin.from('push_subscriptions').select('id, endpoint, subscription');
+  if (targetMemberIds !== null) {
+    query = query.in('member_id', targetMemberIds);
+  }
+  const { data: subscriptions, error: fetchError } = await query;
 
   if (fetchError) {
     throw error(500, 'Failed to fetch subscriptions');

--- a/src/routes/officers/members/+page.svelte
+++ b/src/routes/officers/members/+page.svelte
@@ -14,7 +14,8 @@
     canManageOfficers
   } from '$lib/stores/memberManagementStore';
   import { Hero, Container, LoadingSpinner, EmptyState, Button, OverlappingCard } from '$lib/components/ui';
-  import { Lock, Users, X, RefreshCw, BarChart3, Search, Eye, Edit, Zap, FileText, Download, CheckCircle2, Clock, UserX, UserCheck, AlertCircle } from 'lucide-svelte';
+  import { Lock, Users, X, RefreshCw, BarChart3, Search, Eye, Edit, Zap, FileText, Download, CheckCircle2, Clock, UserX, UserCheck, AlertCircle, Bell, BellOff } from 'lucide-svelte';
+  import { fetchSubscriptionCounts } from '$lib/push/subscriptions';
 
   // Removed tab switching reload - causes issues with Supabase tab switching
   function setupEventHandlers() {
@@ -39,6 +40,20 @@
   let loadingDetails = false;
   let isUpdatingMember = false;
   let unsubscribeVisibility = null;
+
+  // Push-notification reach per member (#135). Map<member_id, deviceCount>;
+  // members absent from the map have no subscribed devices. One aggregate
+  // query, joined client-side against the roster the store already loads.
+  let subscriptionCounts = new Map();
+
+  async function loadSubscriptionCounts() {
+    try {
+      subscriptionCounts = await fetchSubscriptionCounts();
+    } catch (err) {
+      console.error('Failed to load push subscription counts:', err);
+      subscriptionCounts = new Map();
+    }
+  }
 
   // Role options for promotion/demotion
   const roleOptions = [
@@ -267,6 +282,7 @@
 
     // Access control is enforced by officers/+layout; officers only reach here.
     await memberManagementStore.loadMembers();
+    await loadSubscriptionCounts();
   });
 
   onDestroy(() => {
@@ -399,12 +415,14 @@
                   <th>Role</th>
                   <th>Points</th>
                   <th>Activity</th>
+                  <th>Notifications</th>
                   <th>Joined</th>
                   <th>Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {#each $filteredMembers as member}
+                  {@const deviceCount = subscriptionCounts.get(member.id) ?? 0}
                   <tr>
                     <td>
                       <div class="member-info">
@@ -440,6 +458,27 @@
                         <div class="last-activity">Last: {formatDate(member.last_submission_date)}</div>
                       </div>
                     </td>
+                    <td>
+                      {#if deviceCount > 0}
+                        <span
+                          class="notif-badge enabled"
+                          title="{deviceCount} device{deviceCount !== 1 ? 's' : ''} subscribed"
+                        >
+                          <Bell size={12} strokeWidth={2.5} aria-hidden="true" />
+                          <span>Enabled</span>
+                          {#if deviceCount > 1}<span class="notif-count">{deviceCount}</span>{/if}
+                          <span class="sr-only">
+                            — {deviceCount} device{deviceCount !== 1 ? 's' : ''} subscribed
+                          </span>
+                        </span>
+                      {:else}
+                        <span class="notif-badge disabled">
+                          <BellOff size={12} strokeWidth={2.5} aria-hidden="true" />
+                          <span>Off</span>
+                          <span class="sr-only">— no push notifications</span>
+                        </span>
+                      {/if}
+                    </td>
                     <td class="join-date">
                       {formatDate(member.join_date)}
                     </td>
@@ -467,6 +506,7 @@
           <!-- Mobile Cards -->
           <div class="mobile-cards">
             {#each $filteredMembers as member}
+              {@const deviceCount = subscriptionCounts.get(member.id) ?? 0}
               <div class="member-card">
                 <div class="card-header">
                   <div class="member-info">
@@ -505,6 +545,25 @@
                   <div class="stat-item">
                     <span class="stat-label">Joined</span>
                     <span class="stat-value">{formatDate(member.join_date)}</span>
+                  </div>
+                  <div class="stat-item">
+                    <span class="stat-label">Notifications</span>
+                    {#if deviceCount > 0}
+                      <span class="notif-badge enabled">
+                        <Bell size={12} strokeWidth={2.5} aria-hidden="true" />
+                        <span>Enabled</span>
+                        {#if deviceCount > 1}<span class="notif-count">{deviceCount}</span>{/if}
+                        <span class="sr-only">
+                          — {deviceCount} device{deviceCount !== 1 ? 's' : ''} subscribed
+                        </span>
+                      </span>
+                    {:else}
+                      <span class="notif-badge disabled">
+                        <BellOff size={12} strokeWidth={2.5} aria-hidden="true" />
+                        <span>Off</span>
+                        <span class="sr-only">— no push notifications</span>
+                      </span>
+                    {/if}
                   </div>
                 </div>
                 
@@ -1084,6 +1143,44 @@
   .last-activity {
     color: var(--color-gray-500);
     font-size: 0.75rem;
+  }
+
+  /* Push-notification reach badge (#135) */
+  .notif-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: var(--radius-full);
+    font-size: 0.75rem;
+    font-weight: 500;
+    border: 1px solid;
+  }
+
+  .notif-badge.enabled {
+    background: var(--color-success-bg);
+    color: var(--color-success);
+    border-color: var(--color-success-border);
+  }
+
+  .notif-badge.disabled {
+    background: var(--color-gray-50);
+    color: var(--color-gray-500);
+    border-color: var(--color-gray-300);
+  }
+
+  .notif-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.1rem;
+    padding: 0 0.25rem;
+    border-radius: var(--radius-full);
+    background: var(--color-success);
+    color: white;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    line-height: 1.25;
   }
 
   .join-date {

--- a/src/routes/officers/notifications/+page.svelte
+++ b/src/routes/officers/notifications/+page.svelte
@@ -4,14 +4,93 @@
   import { onMount } from 'svelte';
   import toast from 'svelte-french-toast';
   import { Hero, Container, Card, Button } from '$lib/components/ui';
-  import { Bell } from 'lucide-svelte';
+  import { Bell, Users, User, X } from 'lucide-svelte';
+  import { fetchSubscriptionCounts } from '$lib/push/subscriptions';
 
   let title = '';
   let message = '';
   let linkUrl = '';
   let isSending = false;
-  let subscriberCount = null;
   let lastResult = null;
+
+  // ---- Audience targeting (#134) ---------------------------------------
+  // Reach data (member_id → subscribed device count) drives the per-audience
+  // preview; the actual filter is re-enforced server-side. `roster` is the
+  // full member list for the officer/specific pickers.
+  let audienceType = 'all'; // 'all' | 'officers' | 'members'
+  let roster = [];
+  let subscriptionCounts = new Map();
+  let selectedMemberIds = [];
+
+  // Specific-members combobox (mirrors the link picker below)
+  let memberQuery = '';
+  let memberDropdownOpen = false;
+  let memberHighlightedIndex = -1;
+
+  const audienceOptions = [
+    { value: 'all', label: 'All members', icon: Users },
+    { value: 'officers', label: 'Officers only', icon: Bell },
+    { value: 'members', label: 'Specific members', icon: User }
+  ];
+
+  // Member ids in the selected audience (before subscription filtering).
+  $: audienceMemberIds =
+    audienceType === 'all'
+      ? roster.map((m) => m.id)
+      : audienceType === 'officers'
+        ? roster.filter((m) => m.is_officer).map((m) => m.id)
+        : selectedMemberIds;
+
+  // Distinct members in the audience who have ≥1 subscribed device.
+  $: reachCount = audienceMemberIds.filter((id) => subscriptionCounts.has(id)).length;
+  $: audienceSize = audienceMemberIds.length;
+
+  $: selectedMembers = selectedMemberIds
+    .map((id) => roster.find((m) => m.id === id))
+    .filter(Boolean);
+
+  $: filteredRoster = filterRoster(memberQuery, roster, selectedMemberIds);
+
+  function filterRoster(query, all, selected) {
+    const q = query.trim().toLowerCase();
+    const selectedSet = new Set(selected);
+    return all.filter((m) => {
+      if (selectedSet.has(m.id)) return false;
+      if (!q) return true;
+      return m.name?.toLowerCase().includes(q) || m.email?.toLowerCase().includes(q);
+    });
+  }
+
+  function toggleMember(member) {
+    if (selectedMemberIds.includes(member.id)) {
+      selectedMemberIds = selectedMemberIds.filter((id) => id !== member.id);
+    } else {
+      selectedMemberIds = [...selectedMemberIds, member.id];
+    }
+    memberQuery = '';
+    memberHighlightedIndex = -1;
+  }
+
+  function removeMember(id) {
+    selectedMemberIds = selectedMemberIds.filter((m) => m !== id);
+  }
+
+  function handleMemberKeydown(e) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      memberDropdownOpen = true;
+      memberHighlightedIndex = Math.min(memberHighlightedIndex + 1, filteredRoster.length - 1);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      memberHighlightedIndex = Math.max(memberHighlightedIndex - 1, 0);
+    } else if (e.key === 'Enter' && memberDropdownOpen && memberHighlightedIndex >= 0) {
+      e.preventDefault();
+      toggleMember(filteredRoster[memberHighlightedIndex]);
+    } else if (e.key === 'Escape') {
+      memberDropdownOpen = false;
+      memberHighlightedIndex = -1;
+    }
+  }
 
   // ---- Link destination picker (#130 follow-up) ------------------------
   // Free-text links let officers send members to 404s. The link is now
@@ -105,20 +184,39 @@
 
   // Access control is enforced by officers/+layout; officers only reach here.
   onMount(() => {
-    loadSubscriberCount();
+    loadReachData();
+    loadRoster();
     loadEventDestinations();
   });
 
-  async function loadSubscriberCount() {
+  async function loadReachData() {
     try {
-      const { count } = await supabase
-        .from('push_subscriptions')
-        .select('*', { count: 'exact', head: true });
-      subscriberCount = count ?? 0;
+      subscriptionCounts = await fetchSubscriptionCounts();
     } catch (err) {
-      console.error('Failed to load subscriber count:', err);
-      subscriberCount = 0;
+      console.error('Failed to load subscription reach:', err);
+      subscriptionCounts = new Map();
     }
+  }
+
+  async function loadRoster() {
+    try {
+      const { data, error } = await supabase
+        .from('members')
+        .select('id, name, email, is_officer, active')
+        .order('name', { ascending: true });
+      if (error) throw error;
+      // Active members first, then alphabetical (already name-sorted above).
+      roster = (data ?? []).sort((a, b) => (b.active === true) - (a.active === true));
+    } catch (err) {
+      console.error('Failed to load roster:', err);
+      roster = [];
+    }
+  }
+
+  function buildAudiencePayload() {
+    if (audienceType === 'officers') return { type: 'officers' };
+    if (audienceType === 'members') return { type: 'members', memberIds: selectedMemberIds };
+    return { type: 'all' };
   }
 
   async function handleSend() {
@@ -127,8 +225,8 @@
       return;
     }
 
-    if (subscriberCount === 0) {
-      toast.error('No subscribers to send to.');
+    if (audienceType === 'members' && selectedMemberIds.length === 0) {
+      toast.error('Pick at least one member, or choose a different audience.');
       return;
     }
 
@@ -150,7 +248,12 @@
           'Content-Type': 'application/json',
           Authorization: `Bearer ${session.access_token}`
         },
-        body: JSON.stringify({ title: title.trim(), message: message.trim(), url: safeUrl })
+        body: JSON.stringify({
+          title: title.trim(),
+          message: message.trim(),
+          url: safeUrl,
+          audience: buildAudiencePayload()
+        })
       });
 
       const result = await response.json();
@@ -166,8 +269,8 @@
       message = '';
       linkUrl = '';
 
-      // Refresh count (some may have been removed as expired)
-      await loadSubscriberCount();
+      // Refresh reach data (some subscriptions may have been pruned as expired)
+      await loadReachData();
     } catch (err) {
       console.error('Send error:', err);
       toast.error(err.message || 'Failed to send notification.');
@@ -183,7 +286,7 @@
 
 <Hero
     title="Send Notification"
-    subtitle="Push a message to all subscribed members"
+    subtitle="Push a message to members — everyone, officers, or a chosen few"
     backgroundImage="/Jax-Banner.jpg"
     overlay={true}
     compact={true}
@@ -196,23 +299,122 @@
         <div>
           <h2 class="section-title">Broadcast Message</h2>
           <p class="subscriber-info">
-            {#if subscriberCount === null}
-              Loading subscriber count...
+            {#if audienceType === 'all'}
+              <strong>{reachCount}</strong> member{reachCount !== 1 ? 's' : ''} subscribed to notifications
+            {:else if audienceType === 'officers'}
+              <strong>{reachCount}</strong> of {audienceSize} officer{audienceSize !== 1 ? 's' : ''} have notifications enabled
             {:else}
-              <strong>{subscriberCount}</strong> member{subscriberCount !== 1 ? 's' : ''} subscribed to notifications
+              <strong>{reachCount}</strong> of {audienceSize} selected member{audienceSize !== 1 ? 's' : ''} have notifications enabled
             {/if}
           </p>
         </div>
       </div>
 
-      {#if subscriberCount === 0}
+      {#if reachCount === 0}
         <div class="empty-notice">
-          No members have enabled push notifications yet. Members can enable them using the bell
-          icon in the header.
+          {#if audienceType === 'all'}
+            No members have enabled push notifications yet. Members can enable them using the bell
+            icon in the header.
+          {:else if audienceType === 'members' && selectedMemberIds.length === 0}
+            Pick members below to see how many can be reached.
+          {:else}
+            None of this audience has notifications enabled — sending now will reach no one.
+          {/if}
         </div>
       {/if}
 
       <form on:submit|preventDefault={handleSend} class="notification-form">
+        <div class="form-group">
+          <span class="form-label" id="audience-label">Audience</span>
+          <div class="audience-options" role="radiogroup" aria-labelledby="audience-label">
+            {#each audienceOptions as option}
+              <button
+                type="button"
+                role="radio"
+                aria-checked={audienceType === option.value}
+                class="audience-option"
+                class:selected={audienceType === option.value}
+                disabled={isSending}
+                on:click={() => (audienceType = option.value)}
+              >
+                <svelte:component this={option.icon} size={16} strokeWidth={2} />
+                {option.label}
+              </button>
+            {/each}
+          </div>
+        </div>
+
+        {#if audienceType === 'members'}
+          <div class="form-group">
+            <label for="notif-members" class="form-label">Choose members</label>
+            {#if selectedMembers.length > 0}
+              <div class="chips">
+                {#each selectedMembers as m (m.id)}
+                  <span class="chip">
+                    {m.name || m.email}
+                    <button
+                      type="button"
+                      class="chip-remove"
+                      aria-label={`Remove ${m.name || m.email}`}
+                      on:click={() => removeMember(m.id)}
+                      disabled={isSending}
+                    >
+                      <X size={12} strokeWidth={2.5} />
+                    </button>
+                  </span>
+                {/each}
+              </div>
+            {/if}
+            <div class="link-picker">
+              <input
+                id="notif-members"
+                type="text"
+                class="form-control"
+                role="combobox"
+                aria-expanded={memberDropdownOpen}
+                aria-controls="notif-member-options"
+                aria-autocomplete="list"
+                autocomplete="off"
+                bind:value={memberQuery}
+                on:focus={() => (memberDropdownOpen = true)}
+                on:input={() => { memberDropdownOpen = true; memberHighlightedIndex = -1; }}
+                on:keydown={handleMemberKeydown}
+                on:blur={() => setTimeout(() => (memberDropdownOpen = false), 150)}
+                placeholder="Search members by name or email"
+                disabled={isSending}
+              />
+              {#if memberDropdownOpen && filteredRoster.length > 0}
+                <ul id="notif-member-options" class="link-options" role="listbox">
+                  {#each filteredRoster.slice(0, 50) as m, i (m.id)}
+                    <li role="presentation">
+                      <button
+                        type="button"
+                        role="option"
+                        aria-selected={i === memberHighlightedIndex}
+                        class="link-option"
+                        class:highlighted={i === memberHighlightedIndex}
+                        on:mousedown|preventDefault={() => toggleMember(m)}
+                      >
+                        <span class="option-label">
+                          {m.name || m.email}
+                          {#if !m.active}<span class="option-inactive">inactive</span>{/if}
+                        </span>
+                        <span class="option-path">
+                          {subscriptionCounts.has(m.id) ? '🔔 subscribed' : 'no notifications'}
+                        </span>
+                      </button>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </div>
+            <div class="field-hint">
+              Only members with notifications enabled will receive the push — the count above
+              reflects who's reachable.
+            </div>
+          </div>
+        {/if}
+
         <div class="form-group">
           <label for="notif-title" class="form-label">Title <span class="required">*</span></label>
           <input
@@ -306,7 +508,7 @@
           <Button
             variant="primary"
             type="submit"
-            disabled={isSending || !title.trim() || !message.trim() || subscriberCount === 0}
+            disabled={isSending || !title.trim() || !message.trim() || (audienceType === 'members' && selectedMemberIds.length === 0)}
           >
             <Bell size={16} />
             {isSending ? 'Sending...' : 'Send Notification'}
@@ -379,6 +581,86 @@
   .field-hint {
     font-size: var(--font-size-xs);
     color: var(--color-text-secondary);
+  }
+
+  /* Audience selector (#134) */
+  .audience-options {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .audience-option {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--color-border-primary);
+    border-radius: var(--radius-md);
+    background: var(--color-bg-card);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    font-family: inherit;
+    cursor: pointer;
+    transition: border-color 0.2s, background 0.2s, color 0.2s;
+  }
+
+  .audience-option:hover:not(:disabled) {
+    border-color: var(--color-brand-primary);
+  }
+
+  .audience-option.selected {
+    border-color: var(--color-brand-primary);
+    background: var(--color-brand-primary-light);
+    color: var(--color-brand-primary);
+  }
+
+  .audience-option:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-2) var(--space-1) var(--space-3);
+    background: var(--color-brand-primary-light);
+    color: var(--color-brand-primary);
+    border-radius: var(--radius-full);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+  }
+
+  .chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-1);
+    border: none;
+    background: none;
+    color: inherit;
+    cursor: pointer;
+    border-radius: var(--radius-full);
+  }
+
+  .chip-remove:hover:not(:disabled) {
+    background: rgba(0, 0, 0, 0.1);
+  }
+
+  .option-inactive {
+    margin-left: var(--space-2);
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+    font-weight: var(--font-weight-normal);
+    font-style: italic;
   }
 
   .link-picker {


### PR DESCRIPTION
Closes #134
Closes #135

Works both issues together since they share the same "who's subscribed" reach data.

## Shared helper
`src/lib/push/subscriptions.js` — `fetchSubscriptionCounts()` runs a single `select member_id from push_subscriptions` (officer SELECT policy from #96) and returns a `Map<member_id, deviceCount>`. Both pages join it client-side; no N+1.

## #135 — Notification status on `/officers/members`
- New **Notifications** column (desktop table) and **Notifications** stat (mobile cards).
- Bell / BellOff badge matching the header toggle iconography — "Enabled" (green, with a device-count pill when a member has >1 subscribed device) or "Off" (gray).
- Accessible: status conveyed by text + `sr-only` labels (e.g. "— 2 devices subscribed"), not color/icon alone; device count also surfaced as a tooltip.
- Derives from live `push_subscriptions` on each page load.

## #134 — Audience targeting on `/officers/notifications`
**Server (`/api/push/send`):**
- Accepts `audience: { type: 'all' | 'officers' | 'members', memberIds? }`, defaulting to `all` (backward compatible).
- `officers` → resolves `is_officer` ids server-side; `members` → validates non-empty, ≤50, all UUIDs, else **400**.
- Recipient filter is **enforced server-side** — the client only chooses which members, never endpoints.
- Short-circuits to `sent: 0` when the resolved audience has no members.

**UI:**
- Radio-group audience selector: All members (default) / Officers only / Specific members.
- "Specific members" reveals a searchable multi-select combobox (reuses the #132 link-picker pattern) with chips, keyboard nav, active-members-first ordering, and a per-row subscribed/not hint.
- Reach preview updates per audience — e.g. "2 of 7 officers have notifications enabled" — and warns (doesn't block) at zero reach.

## Acceptance criteria
### #135
- [x] Every member row shows subscribed / not subscribed
- [x] Status derives from live `push_subscriptions` rows
- [x] One aggregate query, not N+1
- [x] Rendered in desktop table and mobile cards, with accessible labels

### #134
- [x] Default send behaves exactly as today (all subscribed members)
- [x] "Officers only" reaches only officers' subscriptions (`is_officer`)
- [x] "Specific members" sends only to chosen members; unreachable members shown before sending
- [x] Server rejects malformed audiences (unknown type, empty/oversized/invalid `memberIds`) with 400
- [x] Result banner reflects audience-scoped sent/failed counts

## Testing
- `npm run check` — 0 errors
- `npm run build` — succeeds
- `stylelint` — clean
- Verified reach math against live data (2 subscribed members, both officers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)