### PR TITLE
refactor(logging): gate dev console.log behind a logger util (#60)

### DIFF
--- a/src/lib/stores/memberManagementStore.js
+++ b/src/lib/stores/memberManagementStore.js
@@ -2,6 +2,7 @@
 import { writable, derived, get } from 'svelte/store';
 import { supabase } from '$lib/supabaseClient';
 import { userProfile } from './userProfile';
+import { logger } from '$lib/utils/logger';
 
 // Core data stores
 export const members = writable([]);
@@ -173,7 +174,7 @@ export const memberManagementStore = {
     error.set(null);
     
     try {
-      console.log('🔄 Loading members with points...');
+      logger.log('🔄 Loading members with points...');
       
       const { data, error: fetchError } = await supabase
         .rpc('get_members_with_points');
@@ -182,7 +183,7 @@ export const memberManagementStore = {
         throw fetchError;
       }
       
-      console.log(`✅ Loaded ${data?.length || 0} members`);
+      logger.log(`✅ Loaded ${data?.length || 0} members`);
       
       members.set(data || []);
       lastRefresh.set(Date.now());
@@ -221,7 +222,7 @@ export const memberManagementStore = {
     error.set(null);
     
     try {
-      console.log(`🔄 Updating member ${memberId} role to ${newRole}...`);
+      logger.log(`🔄 Updating member ${memberId} role to ${newRole}...`);
 
       // Determine if the new role should have officer status
       const officerRoles = ['officer', 'competition_director', 'vice_president', 'president'];
@@ -240,7 +241,7 @@ export const memberManagementStore = {
         throw updateError;
       }
       
-      console.log('✅ Member role updated successfully');
+      logger.log('✅ Member role updated successfully');
       
       // Refresh the members list
       await this.loadMembers(true);
@@ -262,7 +263,7 @@ export const memberManagementStore = {
     error.set(null);
     
     try {
-      console.log(`🔄 Loading details for member ${memberId}...`);
+      logger.log(`🔄 Loading details for member ${memberId}...`);
       
       // Get member basic info
       const { data: memberData, error: memberError } = await supabase
@@ -293,7 +294,7 @@ export const memberManagementStore = {
         throw submissionsError;
       }
       
-      console.log(`✅ Loaded member details with ${submissions?.length || 0} recent submissions`);
+      logger.log(`✅ Loaded member details with ${submissions?.length || 0} recent submissions`);
       
       return {
         member: memberData,

--- a/src/lib/utils/logger.js
+++ b/src/lib/utils/logger.js
@@ -1,0 +1,27 @@
+// Small logging shim so dev-only diagnostics don't ship to production (#60).
+//
+// `log`/`debug`/`info` are gated behind Vite's `import.meta.env.DEV`. Because
+// that flag is statically replaced with `false` in production builds, those
+// calls are dead-code-eliminated from the bundle entirely — no log noise, and
+// no leaking of internal data shapes to end-user consoles.
+//
+// `warn`/`error` always pass through: they're intentional diagnostics that we
+// want visible in production. Route future logging through this shim rather
+// than calling `console.*` directly so the dev/prod split stays consistent.
+const isDev = import.meta.env.DEV;
+
+export const logger = {
+  log: (...args) => {
+    if (isDev) console.log(...args);
+  },
+  debug: (...args) => {
+    if (isDev) console.debug(...args);
+  },
+  info: (...args) => {
+    if (isDev) console.info(...args);
+  },
+  warn: (...args) => console.warn(...args),
+  error: (...args) => console.error(...args)
+};
+
+export default logger;

--- a/src/routes/competitions/my-entries/scoresheet/[entryId]/+page.svelte
+++ b/src/routes/competitions/my-entries/scoresheet/[entryId]/+page.svelte
@@ -5,6 +5,7 @@
   import { page } from '$app/stores';
   import { userProfile } from '$lib/stores/userProfile';
   import { supabase } from '$lib/supabaseClient';
+  import { logger } from '$lib/utils/logger';
   import Hero from "$lib/components/ui/Hero.svelte";
   import Container from "$lib/components/ui/Container.svelte";
   import LoadingSpinner from "$lib/components/ui/LoadingSpinner.svelte";
@@ -31,7 +32,7 @@
     error = null;
 
     try {
-      console.log('Loading scoresheet for entry:', entryId);
+      logger.log('Loading scoresheet for entry:', entryId);
 
       // First, verify the entry belongs to the current user
       const { data: entryData, error: entryError } = await supabase

--- a/src/routes/competitions/results/+page.svelte
+++ b/src/routes/competitions/results/+page.svelte
@@ -4,6 +4,7 @@
   import { goto } from '$app/navigation';
   import { userProfile } from '$lib/stores/userProfile';
   import { supabase } from '$lib/supabaseClient';
+  import { logger } from '$lib/utils/logger';
   import { Hero, Container, LoadingSpinner, EmptyState, Button, Badge } from '$lib/components/ui';
   import { Trophy, Medal, Award, ArrowLeft, Calendar } from 'lucide-svelte';
   
@@ -95,7 +96,7 @@
     error = null;
 
     try {
-      console.log('Loading published competitions...');
+      logger.log('Loading published competitions...');
       
       const { data: competitionsData, error: competitionsError } = await supabase
         .from('competitions')
@@ -106,7 +107,7 @@
       if (competitionsError) throw competitionsError;
 
       competitions = competitionsData || [];
-      console.log('Loaded', competitions.length, 'published competitions');
+      logger.log('Loaded', competitions.length, 'published competitions');
 
       // Auto-select the most recent competition if available
       if (competitions.length > 0) {
@@ -144,7 +145,7 @@
     error = null;
 
     try {
-      console.log('Loading results for competition:', competition.name);
+      logger.log('Loading results for competition:', competition.name);
 
       // Get competition results with entry details (excluding judge notes for privacy)
       const { data: resultsData, error: resultsError } = await supabase
@@ -253,7 +254,7 @@
         };
       });
 
-      console.log('Loaded', results.length, 'results');
+      logger.log('Loaded', results.length, 'results');
 
     } catch (err) {
       console.error('Error loading results:', err);

--- a/src/routes/competitions/submit-entry/+page.svelte
+++ b/src/routes/competitions/submit-entry/+page.svelte
@@ -17,6 +17,7 @@
     error
   } from '$lib/stores/bjcpCategoryStore.js';
   import { supabase } from '$lib/supabaseClient';
+  import { logger } from '$lib/utils/logger';
   import { generateUniqueEntryNumber } from '$lib/utils/entryNumber.js';
   import { Hero, Container, LoadingSpinner, EmptyState, Button, Card } from '$lib/components/ui';
   import { Trophy, RotateCcw, Send, CheckCircle, Calendar, Info } from 'lucide-svelte';
@@ -139,7 +140,7 @@
         throw insertError;
       }
 
-      console.log('✅ Entry submitted successfully:', data);
+      logger.log('✅ Entry submitted successfully:', data);
       
       submitSuccess = true;
       

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount, onDestroy } from 'svelte';
   import { supabase } from '$lib/supabaseClient';
+  import { logger } from '$lib/utils/logger';
   import AuthForm from '$lib/components/AuthForm.svelte';
   import { goto } from '$app/navigation';
   import { user } from '$lib/stores/user';
@@ -90,7 +91,7 @@
 
     // Listen for auth state changes
     const { data } = supabase.auth.onAuthStateChange((event, session) => {
-      console.log('Auth state changed:', event, session?.user?.id);
+      logger.log('Auth state changed:', event, session?.user?.id);
       
       // Use setTimeout to make auth operations non-blocking for tab switching
       setTimeout(() => {

--- a/src/routes/my-submissions/+page.svelte
+++ b/src/routes/my-submissions/+page.svelte
@@ -11,6 +11,7 @@
   } from "$lib/stores/mySubmissionsStore.js";
   import { formatDate, formatSubmissionTime } from "$lib/utils/dateUtils.js";
   import { Hero, Container, LoadingSpinner, EmptyState, Button, Card, OverlappingCard } from '$lib/components/ui';
+  import { logger } from '$lib/utils/logger';
   import { CheckCircle, Clock, XCircle, Trophy, ClipboardList, List } from 'lucide-svelte';
 
   let submissions = [];
@@ -73,7 +74,7 @@
 
   function toggleView() {
     showAll = !showAll;
-    console.log("[submissions] toggleView clicked → showAll =", showAll);
+    logger.log("[submissions] toggleView clicked → showAll =", showAll);
   }
 
   function sortTable(column) {
@@ -83,7 +84,7 @@
       sortColumn = column;
       sortDirection = "asc";
     }
-    console.log(
+    logger.log(
       `[submissions] sortTable: sortColumn = ${sortColumn}, sortDirection = ${sortDirection}`,
     );
     loadAllSubmissions(true);
@@ -110,7 +111,7 @@
   function getStatusCounts() {
     // Use the full store data, not the filtered submissions
     const allSubs = $storeAll || [];
-    console.log('Stats calculation - allSubs:', allSubs.length, allSubs);
+    logger.log('Stats calculation - allSubs:', allSubs.length, allSubs);
     
     const approved = allSubs.filter(s => s.approved === true).length;
     const rejected = allSubs.filter(s => s.rejection_reason).length;
@@ -119,7 +120,7 @@
       .filter(s => s.approved === true)
       .reduce((sum, s) => sum + (s.points || 0), 0);
     
-    console.log('Stats result:', { approved, rejected, pending, totalPoints });
+    logger.log('Stats result:', { approved, rejected, pending, totalPoints });
     return { approved, rejected, pending, totalPoints };
   }
 
@@ -128,12 +129,12 @@
 
   // Reload when navigating to submissions page
   $: if ($page.url.pathname === "/my-submissions" && currentUserId) {
-    console.log("[submissions] $page.url.pathname triggered reload");
+    logger.log("[submissions] $page.url.pathname triggered reload");
     loadAllSubmissions(true);
   }
 
   onMount(() => {
-    console.log("[submissions] onMount → initial loadAllSubmissions");
+    logger.log("[submissions] onMount → initial loadAllSubmissions");
     loadAllSubmissions(true);
     
     // Setup tab focus handling

--- a/src/routes/officers/members/+page.svelte
+++ b/src/routes/officers/members/+page.svelte
@@ -14,6 +14,7 @@
     canManageOfficers
   } from '$lib/stores/memberManagementStore';
   import { Hero, Container, LoadingSpinner, EmptyState, Button, OverlappingCard } from '$lib/components/ui';
+  import { logger } from '$lib/utils/logger';
   import { Lock, Users, X, RefreshCw, BarChart3, Search, Eye, Edit, Zap, FileText, Download, CheckCircle2, Clock, UserX, UserCheck, AlertCircle } from 'lucide-svelte';
 
   // Removed tab switching reload - causes issues with Supabase tab switching
@@ -182,7 +183,7 @@
       memberToPromote = null;
       newRole = '';
       
-      console.log('✅ Role updated successfully');
+      logger.log('✅ Role updated successfully');
     } catch (err) {
       console.error('❌ Failed to update role:', err);
     }
@@ -214,7 +215,7 @@
         .eq('id', memberToEdit.id)
         .select();
       if (error) throw error;
-      console.log('✅ Member updated successfully');
+      logger.log('✅ Member updated successfully');
       // Close modal and reset
       showEditModal = false;
       memberToEdit = null;

--- a/src/routes/submit/+page.svelte
+++ b/src/routes/submit/+page.svelte
@@ -20,6 +20,7 @@
   import { get } from "svelte/store";
   import { page } from "$app/stores";
   import { Hero, Container, LoadingSpinner, EmptyState, Button, FormSelect, FormTextarea } from '$lib/components/ui';
+  import { logger } from '$lib/utils/logger';
 
   // Form state
   let selectedCategory = "";
@@ -129,7 +130,7 @@
 
   // Data loading function
   async function loadData(force = false) {
-    console.log(
+    logger.log(
       "🔄 Loading data, force:",
       force,
       "isLoaded:",
@@ -141,7 +142,7 @@
     try {
       await Promise.all([loadCategoryData(force), loadUserProfile(force)]);
 
-      console.log("✅ All data loaded successfully");
+      logger.log("✅ All data loaded successfully");
     } catch (error) {
       console.error("❌ Error loading data:", error);
       toast.error("Failed to load data. Please try again.");


### PR DESCRIPTION
Closes #60

## Summary
Stops shipping `console.log` noise to production consoles. The count had grown to **188** `console.*` calls (125 `error`, 40 `warn`, 23 `log`); the `log` calls are the dev noise the issue targets, including emoji debug lines and a login log that echoed `session.user.id`.

## Approach
New `src/lib/utils/logger.js`:
- `log` / `debug` / `info` are gated behind `import.meta.env.DEV`. Vite replaces that flag with `false` in production, so the branches are **dead-code-eliminated** — the compiled prod logger is literally a set of no-op functions (verified in `.svelte-kit/output`).
- `warn` / `error` pass through unchanged — intentional diagnostics we want in prod.

All 23 `console.log` call sites across 8 files converted to `logger.log` with the import added. Route future logging through this shim to keep the dev/prod split consistent.

## Issue checklist
- [x] Strip / gate `console.log`/`console.debug` behind a dev check
- [x] Keep intentional `console.error`/`warn`; reviewed for leaked sensitive detail — remaining calls log error objects / domain "judging session" state, no tokens or PII. The one sensitive log (login "Auth state changed" with user id) is now dev-gated.
- [x] Added a small logger util for consistency going forward

## Verification
```
npm run check   # 0 errors
npm run build   # succeeds; prod logger chunk = no-op log/debug/info, live warn/error
```
Compiled prod logger:
```js
const logger = {
  log: (...args) => {}, debug: (...args) => {}, info: (...args) => {},
  warn: (...args) => console.warn(...args),
  error: (...args) => console.error(...args)
};
```

## Note
Independent of the open #134/#135 PR (#136). Two touched files (`officers/members`, `memberManagementStore`) also appear in that PR but on non-overlapping lines, so the two should merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)