### PR TITLE
perf(db): leaderboard aggregation RPCs + bounded view-all query (#108)

### DIFF
--- a/src/lib/stores/leaderboardStore.js
+++ b/src/lib/stores/leaderboardStore.js
@@ -11,16 +11,15 @@ const CACHE_MS = 10000;
 const cache = new Map(); // year -> { data, loadedAt }
 
 export async function loadAvailableYears() {
-  const { data, error } = await supabase
-    .from('point_submissions')
-    .select('event_date')
-    .eq('approved', true)
-    .not('event_date', 'is', null);
+  // Distinct years are computed in the DB (get_submission_years) instead of
+  // shipping every approved row's event_date to derive ~5 values client-side.
+  const { data, error } = await supabase.rpc('get_submission_years');
 
   if (error || !data) return;
 
-  const years = [...new Set(data.map(r => new Date(r.event_date + 'T00:00:00').getFullYear()))]
-    .filter(y => !isNaN(y))
+  const years = data
+    .map((y) => Number(y))
+    .filter((y) => !isNaN(y))
     .sort((a, b) => b - a);
 
   // Always include current year even if no data yet
@@ -47,16 +46,10 @@ export async function loadLeaderboard(year, force = false) {
 
   loading.set(true);
 
-  const { data, error } = await supabase
-    .from('point_submissions')
-    .select(`
-      points,
-      member_id,
-      members(id, name)
-    `)
-    .eq('approved', true)
-    .gte('event_date', `${year}-01-01`)
-    .lte('event_date', `${year}-12-31`);
+  // Aggregation happens in the DB (get_leaderboard) — one row per member,
+  // already summed and ordered — rather than shipping every approved row and
+  // summing in a JS Map.
+  const { data, error } = await supabase.rpc('get_leaderboard', { p_year: year });
 
   if (error) {
     console.error('Error loading leaderboard:', error);
@@ -66,17 +59,12 @@ export async function loadLeaderboard(year, force = false) {
     return;
   }
 
-  const totals = new Map();
-  for (const entry of data) {
-    const id = entry.members?.id;
-    const name = entry.members?.name;
-    const points = entry.points || 0;
-    if (!id || !name) continue;
-    if (!totals.has(id)) totals.set(id, { name, points: 0 });
-    totals.get(id).points += points;
-  }
-
-  const sorted = Array.from(totals.values()).sort((a, b) => b.points - a.points);
+  // total_points comes back as a bigint; normalise to a number for the UI,
+  // which calls .toLocaleString() on it.
+  const sorted = (data ?? []).map((row) => ({
+    name: row.name,
+    points: Number(row.total_points) || 0
+  }));
 
   cache.set(year, { data: sorted, loadedAt: Date.now() });
   leaderboard.set(sorted);

--- a/src/lib/stores/viewAllStore.js
+++ b/src/lib/stores/viewAllStore.js
@@ -1,6 +1,5 @@
 import { writable } from 'svelte/store';
 import { supabase } from '$lib/supabaseClient';
-import { browser } from '$app/environment';
 
 export const allSubmissions = writable([]);
 export const message = writable('');
@@ -8,6 +7,12 @@ export const loading = writable(false);
 
 let lastLoaded = 0;
 const CACHE_MS = 10000;
+
+// The view-all page filters and sorts client-side across the whole result, so
+// this still loads a single set rather than true server-side pagination — but
+// it's now bounded. At ~173 rows this is generous headroom; the cap keeps the
+// worst case from shipping an unbounded table as club history grows (#108).
+const MAX_ROWS = 2000;
 
 export async function loadAllSubmissions(force = false) {
   if (!force && Date.now() - lastLoaded < CACHE_MS) return;
@@ -17,13 +22,18 @@ export async function loadAllSubmissions(force = false) {
   const { data, error } = await supabase
     .from('point_submissions')
     .select(`id, category, description, points, event_date, submitted_at, approved, rejection_reason, members(name)`)
-    .order('event_date', { ascending: false });
+    .order('event_date', { ascending: false })
+    .limit(MAX_ROWS);
 
   lastLoaded = Date.now();
 
   if (!error) {
     allSubmissions.set(data);
-    message.set('');
+    // Surface truncation instead of silently dropping older rows once the
+    // table outgrows the cap.
+    message.set(
+      data.length >= MAX_ROWS ? `Showing the most recent ${MAX_ROWS} submissions.` : ''
+    );
   } else {
     console.error('Error loading submissions:', error);
     allSubmissions.set([]);
@@ -31,28 +41,4 @@ export async function loadAllSubmissions(force = false) {
   }
 
   loading.set(false);
-}
-
-if (browser) {
-  setTimeout(() => {
-    try {
-      const stored = localStorage.getItem('viewAllSubmissions');
-      if (stored) {
-        let parsed = JSON.parse(stored);
-        allSubmissions.update((current) => {
-          return Array.isArray(current) && current.length > 0 ? current : parsed;
-        });
-      }
-
-      allSubmissions.subscribe((val) => {
-        try {
-          localStorage.setItem('viewAllSubmissions', JSON.stringify(val));
-        } catch (e) {
-          console.warn('Error saving viewAllSubmissions to localStorage:', e);
-        }
-      });
-    } catch (e) {
-      console.warn('viewAll localStorage error:', e);
-    }
-  }, 0);
 }

--- a/src/routes/officers/view-all/+page.svelte
+++ b/src/routes/officers/view-all/+page.svelte
@@ -4,6 +4,7 @@
     allSubmissions as storeAll,
     loadAllSubmissions,
     loading,
+    message as storeMessage,
   } from "$lib/stores/viewAllStore.js";
   import { formatDate, formatSubmissionTime } from "$lib/utils/dateUtils.js";
   import { Hero, Container, LoadingSpinner, EmptyState, Button } from '$lib/components/ui';
@@ -198,6 +199,9 @@
   {#if $loading}
     <LoadingSpinner message="Loading all submissions..." />
   {:else}
+    {#if $storeMessage}
+      <div class="store-notice">{$storeMessage}</div>
+    {/if}
     <!-- Filter Controls -->
     <div class="controls-section">
       <div class="controls-header">
@@ -516,6 +520,16 @@
 </Container>
 
 <style>
+  .store-notice {
+    background: var(--color-warning-bg-light);
+    border: 1px solid var(--color-warning-bg-soft);
+    color: var(--color-warning-text);
+    border-radius: var(--radius-md);
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    font-size: 0.875rem;
+  }
+
   /* Empty State with Icon */
   .empty-state-with-icon {
     display: flex;

--- a/supabase/migrations/20260720141831_leaderboard_and_years_rpcs.sql
+++ b/supabase/migrations/20260720141831_leaderboard_and_years_rpcs.sql
@@ -1,0 +1,45 @@
+-- Move leaderboard aggregation into the database (#108).
+--
+-- The leaderboard and the year picker previously shipped every approved
+-- point_submissions row to the browser — one RLS check paid per row — and
+-- summed / de-duplicated in JS. These RPCs return one row per member / one
+-- row per year instead, and lean on idx_point_submissions_approved_date
+-- (approved, event_date) from #107.
+--
+-- SECURITY INVOKER (the default) so RLS still applies as the calling user,
+-- matching get_members_with_points. Approved rows are readable by every
+-- authenticated member per the point_submissions SELECT policy, so the
+-- aggregate is correct without elevating privileges.
+
+create or replace function public.get_leaderboard(p_year int)
+returns table (member_id uuid, name text, total_points bigint)
+language sql
+stable
+as $fn$
+  select ps.member_id, m.name, sum(ps.points)::bigint
+  from public.point_submissions ps
+  join public.members m on m.id = ps.member_id
+  where ps.approved = true
+    and ps.event_date >= make_date(p_year, 1, 1)
+    and ps.event_date < make_date(p_year + 1, 1, 1)
+  group by ps.member_id, m.name
+  order by 3 desc;
+$fn$;
+
+create or replace function public.get_submission_years()
+returns setof int
+language sql
+stable
+as $fn$
+  select distinct extract(year from event_date)::int
+  from public.point_submissions
+  where approved = true and event_date is not null
+  order by 1 desc;
+$fn$;
+
+-- EXECUTE is granted to PUBLIC by default; signed-in members only
+-- (mirrors 20260707201355_tighten_function_execute_grants.sql).
+revoke execute on function public.get_leaderboard(int) from public, anon;
+revoke execute on function public.get_submission_years() from public, anon;
+grant execute on function public.get_leaderboard(int) to authenticated;
+grant execute on function public.get_submission_years() to authenticated;


### PR DESCRIPTION
Closes #108

Three query paths fetched entire tables and processed them in the browser, getting linearly slower as club history grows (every row shipped also pays an RLS check). `point_submissions` is ~173 rows across 2025–2026 today, so impact is modest now — but the full-table fetch + client-side sum + localStorage mirror all scale linearly, so this is worth doing before the table grows another year.

## Changes

### New RPCs (migration `20260720141831_leaderboard_and_years_rpcs.sql`)
- **`get_leaderboard(p_year int)`** → `(member_id, name, total_points)`, summed and ordered in the DB. Replaces `loadLeaderboard` fetching every approved row for the year and summing in a JS `Map`.
- **`get_submission_years()`** → distinct years from the DB. Replaces `loadAvailableYears` fetching every approved row's `event_date` to derive ~5 values client-side.

Both are `language sql stable`, **SECURITY INVOKER** (RLS applies as the caller, matching `get_members_with_points`), fully schema-qualified, and lean on the `idx_point_submissions_approved_date (approved, event_date)` index from #107. `EXECUTE` granted to `authenticated` only, revoked from `public`/`anon` — mirrors `20260707201355_tighten_function_execute_grants.sql`.

Migration applied to the live DB via MCP; sums/years cross-checked against raw queries (2026 total 10 = 10; 2025 top-3 correct; years `[2026, 2025]`).

### `viewAllStore.js`
- Added `.limit(2000)` to bound the fetch (the page filters/sorts client-side, so this is a safety cap rather than true server-side pagination — see note).
- Surfaces a **truncation notice** when the cap is hit, wired into the view-all page (which previously ignored the store's `message`, so even the existing error message was dead).
- **Dropped the full-dataset `localStorage` mirror** that re-serialized the entire table into `localStorage['viewAllSubmissions']` on every store change. The 10s in-memory cache remains.

## Scope note
The view-all page filters and sorts client-side across the whole result set, so true `.range()` pagination would require moving all filters/sort server-side — a much larger rewrite. Per the issue ("at minimum `.limit()`"), this bounds the worst case and removes the localStorage concern; full server-side pagination can follow if the table outgrows the cap.

## Pre-existing advisory (not introduced here)
Supabase's linter flags the two new functions with `function_search_path_mutable` — but **all 18 existing functions** carry the same warning (incl. `get_members_with_points`, the pattern the issue said to reuse). These are INVOKER + fully-qualified, so there's no escalation vector. Worth a repo-wide `set search_path` hardening pass as its own ticket rather than fixing 2-of-18 here.

## Verification
- `npm run check` — 0 errors
- `npm run build` — succeeds
- `stylelint` (view-all page) — clean
- RPC output cross-checked against live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)