### PR TITLE
security(db): pin search_path on all public functions (#139)

### DIFF
--- a/supabase/migrations/20260720145848_harden_function_search_path.sql
+++ b/supabase/migrations/20260720145848_harden_function_search_path.sql
@@ -1,0 +1,40 @@
+-- Pin search_path on every public function that still had a mutable one (#139).
+--
+-- A function with no search_path set resolves its unqualified object
+-- references against the *caller's* search_path, which the caller can change.
+-- Pinning it removes that mutability (Supabase linter 0011): pg_catalog is
+-- still searched implicitly-first so built-ins can't be shadowed, and `public`
+-- objects can only be shadowed by someone with CREATE on the schema — which
+-- `authenticated` does not have.
+--
+-- `SET search_path TO 'public'` matches the functions already hardened this
+-- way (is_officer, is_competition_judge, members_restrict_privileged_updates,
+-- competition_entries_restrict_member_writes). This is a config-only change —
+-- no function body is rewritten, so behaviour is unchanged.
+--
+-- SECURITY DEFINER functions are the higher-risk cases (they run with the
+-- owner's privileges) and are listed first.
+
+-- SECURITY DEFINER
+alter function public.get_active_competitions() set search_path to 'public';
+alter function public.get_bjcp_categories() set search_path to 'public';
+alter function public.get_competitions_with_stats() set search_path to 'public';
+alter function public.handle_new_user() set search_path to 'public';
+
+-- SECURITY INVOKER — trigger functions
+alter function public.forum_posts_after_insert() set search_path to 'public';
+alter function public.forum_posts_before_update() set search_path to 'public';
+alter function public.forum_posts_restrict_member_updates() set search_path to 'public';
+alter function public.forum_topics_restrict_member_updates() set search_path to 'public';
+alter function public.sync_officer_status() set search_path to 'public';
+alter function public.update_updated_at_column() set search_path to 'public';
+alter function public.validate_competition_entry_category() set search_path to 'public';
+alter function public.validate_intraclub_self_ranking() set search_path to 'public';
+
+-- SECURITY INVOKER — read RPCs / helpers
+alter function public.generate_entry_number() set search_path to 'public';
+alter function public.get_competition_allowed_categories(uuid) set search_path to 'public';
+alter function public.get_competition_ranking_groups(uuid) set search_path to 'public';
+alter function public.get_leaderboard(integer) set search_path to 'public';
+alter function public.get_members_with_points() set search_path to 'public';
+alter function public.get_submission_years() set search_path to 'public';


### PR DESCRIPTION
Closes #139

## Summary
Every `public` function that lacked a `search_path` resolved its unqualified object references against the **caller's** mutable `search_path` (Supabase linter [0011](https://supabase.com/docs/guides/database/database-linter?lint=0011_function_search_path_mutable)). This pins it on all 18 flagged functions.

## Approach
`ALTER FUNCTION … SET search_path TO 'public'` on each — **config-only, no function body rewritten**, so behaviour is unchanged. This matches the four functions already hardened this exact way (`is_officer`, `is_competition_judge`, `members_restrict_privileged_updates`, `competition_entries_restrict_member_writes`).

Why `'public'` is safe:
- `pg_catalog` is still searched **implicitly first**, so built-ins (`now()`, `make_date`, …) can't be shadowed.
- `public` objects can only be shadowed by a role with `CREATE` on the schema, which `authenticated` does not have.
- The path is now **fixed** — a caller can no longer inject an earlier schema.

I chose this over `SET search_path = ''` + full body qualification: the latter would mean rewriting 11 function bodies, including security-critical trigger functions (officer-restriction, `handle_new_user`), for marginal gain over the pattern the repo already uses.

SECURITY DEFINER functions (higher risk — they run with the owner's privileges) are listed first in the migration.

## Verification
- Applied via MCP. **All 22 public functions now have a pinned `search_path`; 0 mutable.**
- `get_advisors(security)` re-run: **all 18 `function_search_path_mutable` warnings cleared.**
- Re-tested functions with unqualified table refs to confirm resolution still works under the pinned path: `get_active_competitions` (0), `get_members_with_points` (31), `get_leaderboard(2025)` (10), `get_submission_years` (2), `generate_entry_number` (ok).

## Merge order
Two of the altered functions (`get_leaderboard`, `get_submission_years`) are introduced by #108 / PR #138. They exist in the live DB already, but the migration file that *creates* them lands with #138 — so **merge #138 before this** to keep a from-scratch migration replay in order.

## Out of scope (flagged separately)
- **Pre-existing bug found while testing:** `get_bjcp_categories()` does `ORDER BY category_number::INTEGER`, which throws `invalid input syntax for type integer` on the 29 cider/mead rows (`C1`–`C4`, `M1`–`M4`). Independent of this change (body untouched); worth its own ticket/fix.
- The `authenticated_security_definer_function_executable` (0029) advisory on the DEFINER read RPCs remains — noted in #139 as a related-but-separate decision (confirm each is intended to be signed-in-callable, or switch to INVOKER).

🤖 Generated with [Claude Code](https://claude.com/claude-code)