### PR TITLE
fix(db): get_bjcp_categories cast-safe ordering for cider/mead (#141)

### DIFF
--- a/supabase/migrations/20260720150706_fix_bjcp_categories_ordering.sql
+++ b/supabase/migrations/20260720150706_fix_bjcp_categories_ordering.sql
@@ -1,0 +1,53 @@
+-- Fix get_bjcp_categories() crashing on non-numeric category numbers (#141).
+--
+-- The function ordered by `category_number::INTEGER`, which raises
+-- 22P02 invalid_text_representation on cider (C1–C4) and mead (M1–M4) rows,
+-- aborting the whole RETURN QUERY so the RPC yields nothing.
+--
+-- Replace the cast with a cast-safe natural sort: order by the leading numeric
+-- run (NULL for a non-numeric prefix, sorted last), then the raw category
+-- number, then subcategory letter. Numbered beer categories keep their numeric
+-- order (1, 2, … 34); cider/mead fall after them, alphabetically.
+--
+-- create-or-replace preserves the existing SECURITY DEFINER and the pinned
+-- search_path from #140. Only the ORDER BY changed.
+
+create or replace function public.get_bjcp_categories()
+returns table(
+  id uuid,
+  category_number character varying,
+  category_name character varying,
+  subcategory_letter character varying,
+  subcategory_name character varying,
+  description text,
+  full_name text,
+  created_at timestamp without time zone,
+  updated_at timestamp without time zone
+)
+language plpgsql
+security definer
+set search_path to 'public'
+as $function$
+BEGIN
+    RETURN QUERY
+    SELECT
+        bc.id,
+        bc.category_number,
+        bc.category_name,
+        bc.subcategory_letter,
+        bc.subcategory_name,
+        bc.description,
+        CASE
+            WHEN bc.subcategory_letter IS NOT NULL THEN
+                (bc.category_number || bc.subcategory_letter || ' - ' || bc.subcategory_name)::TEXT
+            ELSE
+                (bc.category_number || ' - ' || bc.category_name)::TEXT
+        END as full_name,
+        bc.created_at,
+        bc.updated_at
+    FROM bjcp_categories bc
+    ORDER BY nullif(regexp_replace(bc.category_number, '\D.*$', ''), '')::int nulls last,
+             bc.category_number,
+             bc.subcategory_letter;
+END;
+$function$;


### PR DESCRIPTION
Closes #141

## Problem
`get_bjcp_categories()` ordered by `category_number::INTEGER`. The `bjcp_categories` table has 29 rows with non-numeric numbers — cider (`C1`–`C4`) and mead (`M1`–`M4`) — so the cast raised:

```
ERROR: 22P02: invalid input syntax for type integer: "C1"
```

Because the error fired inside `RETURN QUERY`, the RPC returned **nothing** — broken for the entire category set, not just cider/mead.

## Fix
Cast-safe natural sort, no body logic otherwise changed:

```sql
ORDER BY nullif(regexp_replace(bc.category_number, '\D.*$', ''), '')::int nulls last,
         bc.category_number,
         bc.subcategory_letter
```

- Leading numeric run drives the sort → numbered beer categories keep numeric order (1, 2, … 34, not lexical 1, 10, 11, 2).
- A non-numeric prefix yields `NULL` → `nulls last`, so cider then mead fall after the numbered categories, alphabetically.

`create or replace` preserves the existing **SECURITY DEFINER** and the **pinned `search_path`** from #140 — verified post-apply (`prosecdef=true`, `proconfig={search_path=public}`).

## Verification
- Applied via MCP.
- `select count(*) from get_bjcp_categories()` → **151 rows** (previously threw `22P02`).
- Boundary spot-checked: rows 1–133 numbered categories, then `C1`–`C4`, then `M1`–`M4` at the tail (rn 140–151).

## Note
The sibling `get_competition_allowed_categories(uuid)` orders by `bc.category_number` **without** a cast, so it doesn't crash — but it does sort lexically (1, 10, 11, 2). Left as-is here to keep this fix scoped to the crash; a follow-up could apply the same natural-sort expression for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)