### PR TITLE
test: vitest + unit tests for date & entry-number logic (#80)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+# .github/workflows/test.yml
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - develop
+  workflow_dispatch:
+
+jobs:
+  # Unit tests (vitest) — pure logic: date utils, entry-number generation (#80).
+  unit:
+    name: vitest unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,11 @@
         "svelte": "^5.56.4",
         "svelte-check": "^4.4.0",
         "typescript": "^5.0.0",
-        "vite": "^7.0.0"
+        "vite": "^7.0.0",
+        "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1968,10 +1972,28 @@
         "vite": "^6.3.0 || ^7.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2025,6 +2047,129 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -2127,6 +2272,16 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astral-regex": {
@@ -2234,6 +2389,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -2290,6 +2455,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2583,6 +2755,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
@@ -2654,6 +2833,16 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3570,6 +3759,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3995,6 +4191,13 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4061,6 +4264,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -4070,6 +4280,13 @@
       "engines": {
         "node": ">=0.1.14"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -4384,6 +4601,23 @@
         "utrie": "^1.0.2"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -4399,6 +4633,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -4563,6 +4807,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-push": {
       "version": "3.6.7",
       "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
@@ -4593,6 +4927,23 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint:css": "stylelint 'src/**/*.{css,svelte}'",
-    "lint:inline": "node scripts/check-inline-styles.js"
+    "lint:inline": "node scripts/check-inline-styles.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.0.0",
@@ -27,7 +29,8 @@
     "svelte": "^5.56.4",
     "svelte-check": "^4.4.0",
     "typescript": "^5.0.0",
-    "vite": "^7.0.0"
+    "vite": "^7.0.0",
+    "vitest": "^4.1.10"
   },
   "type": "module",
   "dependencies": {

--- a/src/lib/utils/dateUtils.test.js
+++ b/src/lib/utils/dateUtils.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  formatDate,
+  formatDateTime,
+  formatSubmissionTime,
+  formatDateForInput,
+  getTodayForInput,
+  isToday,
+  getRelativeTime
+} from './dateUtils.js';
+
+// Timezone is pinned to UTC in vitest.setup.js, so locale-formatted output is
+// deterministic. Node 22 ships full ICU, so 'en-US' month abbreviations are stable.
+
+describe('formatDate', () => {
+  it('formats a date-only string without timezone drift', () => {
+    expect(formatDate('2025-08-29')).toBe('Aug 29, 2025');
+  });
+
+  it('formats a space-separated timestamp with microseconds', () => {
+    expect(formatDate('2025-08-29 03:43:21.894974')).toBe('Aug 29, 2025');
+  });
+
+  it('formats an ISO timestamp', () => {
+    expect(formatDate('2025-12-01T12:00:00Z')).toBe('Dec 1, 2025');
+  });
+
+  it('honors custom formatting options', () => {
+    expect(formatDate('2025-08-29', { month: 'long' })).toBe('August 29, 2025');
+  });
+
+  it.each([null, undefined, ''])('returns "Invalid Date" for %s', (input) => {
+    expect(formatDate(input)).toBe('Invalid Date');
+  });
+
+  it('returns "Invalid Date" for an unparseable string', () => {
+    expect(formatDate('not-a-date')).toBe('Invalid Date');
+  });
+});
+
+describe('formatDateTime', () => {
+  it('returns a formatted string for a valid timestamp', () => {
+    expect(formatDateTime('2025-08-29 03:43:21.894974')).toContain('Aug 29, 2025');
+  });
+
+  it('returns "Invalid Date" for empty input', () => {
+    expect(formatDateTime('')).toBe('Invalid Date');
+  });
+});
+
+describe('formatSubmissionTime', () => {
+  it('returns a formatted string for a valid timestamp', () => {
+    expect(formatSubmissionTime('2025-07-12 16:34:36.733+00')).not.toBe('Invalid Date');
+  });
+
+  it('returns "Invalid Date" for null input', () => {
+    expect(formatSubmissionTime(null)).toBe('Invalid Date');
+  });
+});
+
+describe('formatDateForInput', () => {
+  it('formats a Date object as YYYY-MM-DD', () => {
+    expect(formatDateForInput(new Date(Date.UTC(2025, 7, 9)))).toBe('2025-08-09');
+  });
+
+  it('zero-pads month and day', () => {
+    expect(formatDateForInput(new Date(Date.UTC(2025, 0, 5)))).toBe('2025-01-05');
+  });
+
+  it('accepts an ISO string', () => {
+    expect(formatDateForInput('2025-11-20T00:00:00Z')).toBe('2025-11-20');
+  });
+});
+
+describe('getTodayForInput', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("returns today's date in YYYY-MM-DD", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-14T10:00:00Z'));
+    expect(getTodayForInput()).toBe('2026-03-14');
+  });
+});
+
+describe('isToday', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('is true for the current day and false otherwise', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-14T10:00:00Z'));
+    expect(isToday('2026-03-14T23:00:00Z')).toBe(true);
+    expect(isToday('2026-03-13T10:00:00Z')).toBe(false);
+  });
+});
+
+describe('getRelativeTime', () => {
+  afterEach(() => vi.useRealTimers());
+
+  const now = new Date('2026-03-14T12:00:00Z');
+  const ago = (ms) => new Date(now.getTime() - ms).toISOString();
+
+  it.each([
+    ['30 seconds', 30 * 1000, 'Just now'],
+    ['5 minutes', 5 * 60 * 1000, '5 minutes ago'],
+    ['1 minute (singular)', 60 * 1000, '1 minute ago'],
+    ['2 hours', 2 * 60 * 60 * 1000, '2 hours ago'],
+    ['3 days', 3 * 24 * 60 * 60 * 1000, '3 days ago']
+  ])('renders %s as "%s"', (_label, offset, expected) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    expect(getRelativeTime(ago(offset))).toBe(expected);
+  });
+
+  it('falls back to an absolute date for older timestamps', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    // 10 days ago → outside the relative window → formatted date
+    expect(getRelativeTime('2026-03-04')).toBe('Mar 4, 2026');
+  });
+});

--- a/src/lib/utils/entryNumber.test.js
+++ b/src/lib/utils/entryNumber.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the Supabase client. The query builder is chainable and thenable: each
+// awaited query pulls the next queued { count, error } result, so we can script
+// collisions and errors. Shared state is created inside vi.hoisted because
+// vi.mock factories are hoisted above the imports.
+const h = vi.hoisted(() => {
+  const state = { queue: [], fromCalls: 0 };
+  const query = {
+    select() {
+      return query;
+    },
+    eq() {
+      return query;
+    },
+    then(onFulfilled, onRejected) {
+      const result = state.queue.shift() ?? { count: 0, error: null };
+      return Promise.resolve(result).then(onFulfilled, onRejected);
+    }
+  };
+  const supabase = {
+    from() {
+      state.fromCalls++;
+      return query;
+    }
+  };
+  return { state, supabase };
+});
+
+vi.mock('$lib/supabaseClient', () => ({ supabase: h.supabase }));
+
+import { generateUniqueEntryNumber } from './entryNumber.js';
+
+describe('generateUniqueEntryNumber', () => {
+  beforeEach(() => {
+    h.state.queue = [];
+    h.state.fromCalls = 0;
+  });
+
+  it('returns a zero-padded 5-digit string when the candidate is free', async () => {
+    h.state.queue = [{ count: 0, error: null }];
+    const entryNumber = await generateUniqueEntryNumber('comp-1');
+    expect(entryNumber).toMatch(/^\d{5}$/);
+    expect(h.state.fromCalls).toBe(1);
+  });
+
+  it('retries on a collision and returns the next free candidate', async () => {
+    h.state.queue = [
+      { count: 1, error: null }, // taken
+      { count: 0, error: null } // free
+    ];
+    const entryNumber = await generateUniqueEntryNumber('comp-1');
+    expect(entryNumber).toMatch(/^\d{5}$/);
+    expect(h.state.fromCalls).toBe(2);
+  });
+
+  it('throws after exhausting maxAttempts collisions', async () => {
+    h.state.queue = [
+      { count: 1, error: null },
+      { count: 1, error: null },
+      { count: 1, error: null }
+    ];
+    await expect(generateUniqueEntryNumber('comp-1', 3)).rejects.toThrow(
+      /unique entry number after maximum attempts/i
+    );
+    expect(h.state.fromCalls).toBe(3);
+  });
+
+  it('throws with the underlying message when the uniqueness check errors', async () => {
+    h.state.queue = [{ count: null, error: { message: 'boom' } }];
+    await expect(generateUniqueEntryNumber('comp-1')).rejects.toThrow(
+      /Failed to check entry number uniqueness: boom/
+    );
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+// Standalone unit-test config (#80). Kept separate from vite.config.js so it
+// doesn't load the SvelteKit plugin — these are fast, pure-logic unit tests.
+// Playwright end-to-end specs live in ./tests and are run by playwright.config.js;
+// vitest only picks up co-located src/**/*.test.js files.
+export default defineConfig({
+  resolve: {
+    alias: {
+      $lib: fileURLToPath(new URL('./src/lib', import.meta.url))
+    }
+  },
+  test: {
+    include: ['src/**/*.{test,spec}.{js,ts}'],
+    environment: 'node',
+    setupFiles: ['./vitest.setup.js']
+  }
+});

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,4 @@
+// Pin the timezone so date-formatting assertions are deterministic across
+// machines and CI. Node re-reads process.env.TZ for subsequent Date/Intl
+// operations, so setting it here (before the tests run) is enough.
+process.env.TZ = 'UTC';


### PR DESCRIPTION
Addresses #80 (first increment — unit tests + CI).

The repo had **no test runner, script, or unit tests** — everything was verified manually. This sets up vitest and covers the pure logic first, exactly where the issue points (utils + entry-number generation).

## What's added
- **vitest** (dev dependency) + `npm test` / `npm run test:watch`.
- **`vitest.config.js`** — standalone (no SvelteKit plugin, stays fast), scoped to `src/**/*.test.js` so it never picks up the Playwright specs in `./tests`; `$lib` alias wired for mocking.
- **`vitest.setup.js`** — pins `TZ=UTC` so date-formatting assertions are deterministic across machines/CI.
- **`src/lib/utils/dateUtils.test.js`** — `formatDate` (date-only vs timestamp, microsecond truncation, custom options, invalid/empty), `formatDateTime`, `formatSubmissionTime`, `formatDateForInput`, `getTodayForInput`, `isToday`, `getRelativeTime` (fake timers for now-relative helpers).
- **`src/lib/utils/entryNumber.test.js`** — `generateUniqueEntryNumber` with a mocked Supabase client scripting free/collision/error paths: 5-digit format, retry-on-collision, throw-after-maxAttempts, error propagation.
- **`.github/workflows/test.yml`** — a `Test` workflow running vitest on PRs (matches the existing `lint.yml` style).

## Result
```
Test Files  2 passed (2)
     Tests  27 passed (27)
```
`npm run check` (0 errors) and `npm run build` still pass.

## Scope / what's deferred
- **Points/ranking computation** (checkbox 1's second half) lives inside Svelte components/stores today, not pure functions. Extracting it into testable units is a real refactor — worth its own PR so this one stays a clean foundation.
- **Playwright smoke test** (login → submit → approve) is the issue's explicit "longer-term" item. Orphaned specs already exist in `./tests` but need a running app + seeded test DB + credentials to go green; left untouched here.

Suggested follow-ups: extract scoring/ranking into pure functions + tests; wire up the Playwright happy-path smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)