### PR TITLE
refactor: extract competition scoring/ranking into a pure, tested module (#80)

### DIFF
--- a/src/lib/utils/scoring.js
+++ b/src/lib/utils/scoring.js
@@ -1,0 +1,127 @@
+// Pure competition scoring / ranking logic (#80).
+//
+// Extracted from the judging-dashboard and the two results pages, which each
+// carried their own copy of the point table and compilation logic. Keeping it
+// here — free of Svelte/Supabase — makes the riskiest math unit-testable and
+// single-sourced.
+
+// Point system: 1st = 3pts, 2nd = 2pts, 3rd = 1pt, everything else 0.
+export const POINTS_BY_RANK = { 1: 3, 2: 2, 3: 1 };
+
+/**
+ * Points awarded for a single judge's rank of an entry.
+ * @param {number} rankPosition
+ * @returns {number}
+ */
+export function getPointsForRanking(rankPosition) {
+  return POINTS_BY_RANK[rankPosition] ?? 0;
+}
+
+/**
+ * A ranking group's category ids, whether stored as a jsonb array or a JSON
+ * string. Returns null when it can't be parsed.
+ */
+export function parseCategoryIds(group) {
+  if (!group) return null;
+  try {
+    return Array.isArray(group.bjcp_category_ids)
+      ? group.bjcp_category_ids
+      : JSON.parse(group.bjcp_category_ids);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The id of the custom ranking group that contains a category, or null when the
+ * category isn't part of any group (i.e. it ranks on its own).
+ */
+export function findRankingGroupIdForCategory(categoryId, rankingGroups = []) {
+  for (const group of rankingGroups) {
+    const categoryIds = parseCategoryIds(group);
+    if (categoryIds && categoryIds.includes(categoryId)) return group.id;
+  }
+  return null;
+}
+
+/**
+ * Sum an entry's points across every judge. When a groupId is given the entry
+ * is ranked within that custom group; otherwise within its own category.
+ * @returns {{ totalPoints: number, judgeCount: number, rankings: object[] }}
+ */
+export function compileEntryPoints(rankings = [], entryId, { categoryId = null, groupId = null } = {}) {
+  const entryRankings = rankings.filter((r) =>
+    r.entry_id === entryId &&
+    (groupId ? r.ranking_group_id === groupId : r.bjcp_category_id === categoryId)
+  );
+  const totalPoints = entryRankings.reduce((sum, r) => sum + getPointsForRanking(r.rank_position), 0);
+  return { totalPoints, judgeCount: entryRankings.length, rankings: entryRankings };
+}
+
+/**
+ * Results-page convenience: resolve the entry's ranking group from its category,
+ * then compile its points. Mirrors the signature the results pages already used.
+ */
+export function calculateEntryPoints(entryId, categoryId, rankings = [], rankingGroups = []) {
+  const groupId = findRankingGroupIdForCategory(categoryId, rankingGroups);
+  return compileEntryPoints(rankings, entryId, { categoryId, groupId });
+}
+
+/** True when more than one distinct judge appears in the rankings. */
+export function hasMultipleJudges(rankings = []) {
+  return new Set(rankings.map((r) => r.judge_id)).size > 1;
+}
+
+/** De-duplicated entry objects pulled from a list of rankings, order preserved. */
+export function getUniqueEntriesFromRankings(rankings = []) {
+  const entryMap = new Map();
+  for (const ranking of rankings) {
+    if (ranking.entry_id && !entryMap.has(ranking.entry_id)) {
+      entryMap.set(ranking.entry_id, ranking.entry);
+    }
+  }
+  return Array.from(entryMap.values());
+}
+
+/**
+ * Average judging score for an entry across its completed sessions (those with
+ * total_score > 0), rounded to one decimal. Returns zeros when none completed.
+ */
+export function computeEntryScoreStats(sessions = [], entryId) {
+  const entryScores = sessions.filter((s) => s.entry_id === entryId && s.total_score > 0);
+  if (entryScores.length === 0) return { count: 0, average: 0, scores: [] };
+  const scores = entryScores.map((s) => s.total_score);
+  const average = Math.round((scores.reduce((sum, v) => sum + v, 0) / scores.length) * 10) / 10;
+  return { count: entryScores.length, average, scores, sessions: entryScores };
+}
+
+/** Placement label for a final rank position: 1/2/3, HM for 4th–5th, else null. */
+export function placementForRank(rankPosition) {
+  if (rankPosition === 1) return '1';
+  if (rankPosition === 2) return '2';
+  if (rankPosition === 3) return '3';
+  if (rankPosition <= 5) return 'HM';
+  return null;
+}
+
+/**
+ * Order entries by compiled points (desc), breaking ties by average score
+ * (desc), and assign each a 1-based rankPosition and placement. Only entries
+ * that actually earned points receive a placement. Input is not mutated.
+ *
+ * @param {{ totalPoints: number, averageScore: number }[]} entries
+ */
+export function rankEntries(entries = []) {
+  const sorted = [...entries].sort((a, b) => {
+    if (b.totalPoints !== a.totalPoints) return b.totalPoints - a.totalPoints;
+    return b.averageScore - a.averageScore;
+  });
+  return sorted.map((entry, index) => {
+    const rankPosition = index + 1;
+    return {
+      ...entry,
+      rankPosition,
+      placement: entry.totalPoints > 0 ? placementForRank(rankPosition) : null
+    };
+  });
+}

--- a/src/lib/utils/scoring.test.js
+++ b/src/lib/utils/scoring.test.js
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getPointsForRanking,
+  parseCategoryIds,
+  findRankingGroupIdForCategory,
+  compileEntryPoints,
+  calculateEntryPoints,
+  hasMultipleJudges,
+  getUniqueEntriesFromRankings,
+  computeEntryScoreStats,
+  placementForRank,
+  rankEntries
+} from './scoring.js';
+
+describe('getPointsForRanking', () => {
+  it.each([
+    [1, 3],
+    [2, 2],
+    [3, 1],
+    [4, 0],
+    [10, 0],
+    [0, 0],
+    [undefined, 0]
+  ])('rank %s → %s pts', (rank, pts) => {
+    expect(getPointsForRanking(rank)).toBe(pts);
+  });
+});
+
+describe('parseCategoryIds', () => {
+  it('returns an array as-is', () => {
+    expect(parseCategoryIds({ bjcp_category_ids: ['a', 'b'] })).toEqual(['a', 'b']);
+  });
+
+  it('parses a JSON string', () => {
+    expect(parseCategoryIds({ bjcp_category_ids: '["a","b"]' })).toEqual(['a', 'b']);
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(parseCategoryIds({ bjcp_category_ids: '{not json' })).toBeNull();
+  });
+
+  it('returns null for a missing group', () => {
+    expect(parseCategoryIds(null)).toBeNull();
+  });
+});
+
+describe('findRankingGroupIdForCategory', () => {
+  const groups = [
+    { id: 'g1', bjcp_category_ids: ['cat-a', 'cat-b'] },
+    { id: 'g2', bjcp_category_ids: '["cat-c"]' }
+  ];
+
+  it('finds the group holding the category (array form)', () => {
+    expect(findRankingGroupIdForCategory('cat-b', groups)).toBe('g1');
+  });
+
+  it('finds the group holding the category (JSON-string form)', () => {
+    expect(findRankingGroupIdForCategory('cat-c', groups)).toBe('g2');
+  });
+
+  it('returns null when no group contains the category', () => {
+    expect(findRankingGroupIdForCategory('cat-z', groups)).toBeNull();
+  });
+
+  it('skips groups whose ids fail to parse', () => {
+    expect(findRankingGroupIdForCategory('cat-a', [{ id: 'bad', bjcp_category_ids: '{' }])).toBeNull();
+  });
+});
+
+describe('compileEntryPoints', () => {
+  const rankings = [
+    { entry_id: 'e1', bjcp_category_id: 'cat-a', judge_id: 'j1', rank_position: 1 }, // 3
+    { entry_id: 'e1', bjcp_category_id: 'cat-a', judge_id: 'j2', rank_position: 2 }, // 2
+    { entry_id: 'e1', ranking_group_id: 'grp', judge_id: 'j3', rank_position: 1 }, // group, 3
+    { entry_id: 'e2', bjcp_category_id: 'cat-a', judge_id: 'j1', rank_position: 1 }
+  ];
+
+  it('sums points across judges within a category', () => {
+    const result = compileEntryPoints(rankings, 'e1', { categoryId: 'cat-a' });
+    expect(result).toEqual({
+      totalPoints: 5,
+      judgeCount: 2,
+      rankings: [rankings[0], rankings[1]]
+    });
+  });
+
+  it('compiles within a custom group when groupId is given', () => {
+    const result = compileEntryPoints(rankings, 'e1', { groupId: 'grp' });
+    expect(result.totalPoints).toBe(3);
+    expect(result.judgeCount).toBe(1);
+  });
+
+  it('returns zeros for an entry with no rankings', () => {
+    expect(compileEntryPoints(rankings, 'nobody', { categoryId: 'cat-a' })).toEqual({
+      totalPoints: 0,
+      judgeCount: 0,
+      rankings: []
+    });
+  });
+
+  it('defaults to an empty ranking list', () => {
+    expect(compileEntryPoints(undefined, 'e1', { categoryId: 'cat-a' }).totalPoints).toBe(0);
+  });
+});
+
+describe('calculateEntryPoints', () => {
+  const rankingGroups = [{ id: 'grp', bjcp_category_ids: ['cat-a'] }];
+  const rankings = [
+    { entry_id: 'e1', ranking_group_id: 'grp', judge_id: 'j1', rank_position: 1 }, // 3 (group)
+    { entry_id: 'e1', bjcp_category_id: 'cat-a', judge_id: 'j2', rank_position: 1 } // ignored: category is grouped
+  ];
+
+  it('resolves the group from the category, then compiles within the group', () => {
+    const result = calculateEntryPoints('e1', 'cat-a', rankings, rankingGroups);
+    expect(result.totalPoints).toBe(3);
+    expect(result.judgeCount).toBe(1);
+  });
+
+  it('compiles by category when the category is in no group', () => {
+    const soloRankings = [
+      { entry_id: 'e1', bjcp_category_id: 'cat-solo', judge_id: 'j1', rank_position: 2 }
+    ];
+    expect(calculateEntryPoints('e1', 'cat-solo', soloRankings, rankingGroups).totalPoints).toBe(2);
+  });
+});
+
+describe('hasMultipleJudges', () => {
+  it('is true for two or more distinct judges', () => {
+    expect(hasMultipleJudges([{ judge_id: 'j1' }, { judge_id: 'j2' }])).toBe(true);
+  });
+
+  it('is false for a single judge (even across multiple rows)', () => {
+    expect(hasMultipleJudges([{ judge_id: 'j1' }, { judge_id: 'j1' }])).toBe(false);
+  });
+
+  it('is false for no rankings', () => {
+    expect(hasMultipleJudges([])).toBe(false);
+  });
+});
+
+describe('getUniqueEntriesFromRankings', () => {
+  it('dedupes by entry_id, preserving first occurrence and order', () => {
+    const rankings = [
+      { entry_id: 'e1', entry: { id: 'e1', name: 'A' } },
+      { entry_id: 'e2', entry: { id: 'e2', name: 'B' } },
+      { entry_id: 'e1', entry: { id: 'e1', name: 'A-dup' } }
+    ];
+    expect(getUniqueEntriesFromRankings(rankings)).toEqual([
+      { id: 'e1', name: 'A' },
+      { id: 'e2', name: 'B' }
+    ]);
+  });
+
+  it('ignores rankings without an entry_id', () => {
+    expect(getUniqueEntriesFromRankings([{ entry: { id: 'x' } }])).toEqual([]);
+  });
+});
+
+describe('computeEntryScoreStats', () => {
+  const sessions = [
+    { entry_id: 'e1', total_score: 40 },
+    { entry_id: 'e1', total_score: 35 },
+    { entry_id: 'e1', total_score: 0 }, // incomplete, excluded
+    { entry_id: 'e2', total_score: 30 }
+  ];
+
+  it('averages completed sessions for the entry, rounded to one decimal', () => {
+    const stats = computeEntryScoreStats(sessions, 'e1');
+    expect(stats.count).toBe(2);
+    expect(stats.average).toBe(37.5);
+    expect(stats.scores).toEqual([40, 35]);
+    expect(stats.sessions).toHaveLength(2);
+  });
+
+  it('rounds to a single decimal place', () => {
+    const s = [
+      { entry_id: 'e', total_score: 40 },
+      { entry_id: 'e', total_score: 41 },
+      { entry_id: 'e', total_score: 41 }
+    ];
+    // (40+41+41)/3 = 40.666… → 40.7
+    expect(computeEntryScoreStats(s, 'e').average).toBe(40.7);
+  });
+
+  it('returns zeros (and no sessions key) when nothing is completed', () => {
+    expect(computeEntryScoreStats(sessions, 'nobody')).toEqual({ count: 0, average: 0, scores: [] });
+  });
+});
+
+describe('placementForRank', () => {
+  it.each([
+    [1, '1'],
+    [2, '2'],
+    [3, '3'],
+    [4, 'HM'],
+    [5, 'HM'],
+    [6, null],
+    [99, null]
+  ])('rank %s → %s', (rank, placement) => {
+    expect(placementForRank(rank)).toBe(placement);
+  });
+});
+
+describe('rankEntries', () => {
+  it('orders by points desc, then average score, and assigns placements', () => {
+    const ranked = rankEntries([
+      { id: 'a', totalPoints: 3, averageScore: 38 },
+      { id: 'b', totalPoints: 6, averageScore: 40 },
+      { id: 'c', totalPoints: 3, averageScore: 42 }
+    ]);
+    expect(ranked.map((e) => e.id)).toEqual(['b', 'c', 'a']); // c beats a on tiebreak
+    expect(ranked.map((e) => e.rankPosition)).toEqual([1, 2, 3]);
+    expect(ranked.map((e) => e.placement)).toEqual(['1', '2', '3']);
+  });
+
+  it('awards HM to 4th and 5th, nothing past 5th', () => {
+    const entries = Array.from({ length: 6 }, (_, i) => ({
+      id: `e${i}`,
+      totalPoints: 6 - i, // strictly descending so order is stable
+      averageScore: 0
+    }));
+    const ranked = rankEntries(entries);
+    expect(ranked.map((e) => e.placement)).toEqual(['1', '2', '3', 'HM', 'HM', null]);
+  });
+
+  it('never places an entry that earned zero points', () => {
+    const ranked = rankEntries([
+      { id: 'a', totalPoints: 0, averageScore: 45 },
+      { id: 'b', totalPoints: 0, averageScore: 30 }
+    ]);
+    expect(ranked.every((e) => e.placement === null)).toBe(true);
+    // rank positions are still assigned by the sort
+    expect(ranked.map((e) => e.id)).toEqual(['a', 'b']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      { id: 'a', totalPoints: 1, averageScore: 1 },
+      { id: 'b', totalPoints: 2, averageScore: 1 }
+    ];
+    const snapshot = JSON.parse(JSON.stringify(input));
+    rankEntries(input);
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/src/routes/competitions/results/+page.svelte
+++ b/src/routes/competitions/results/+page.svelte
@@ -5,6 +5,7 @@
   import { userProfile } from '$lib/stores/userProfile';
   import { supabase } from '$lib/supabaseClient';
   import { logger } from '$lib/utils/logger';
+  import { calculateEntryPoints } from '$lib/utils/scoring';
   import { Hero, Container, LoadingSpinner, EmptyState, Button, Badge } from '$lib/components/ui';
   import { Trophy, Medal, Award, ArrowLeft, Calendar } from 'lucide-svelte';
   
@@ -32,63 +33,7 @@
     // Cleanup handled by setupEventHandlers return
   });
 
-  // Helper functions for ranking points calculation
-  function getPointsForRanking(rankPosition) {
-    // Point system: 1st=3pts, 2nd=2pts, 3rd=1pt, others=0pts
-    switch (rankPosition) {
-      case 1: return 3;
-      case 2: return 2;
-      case 3: return 1;
-      default: return 0;
-    }
-  }
-
-  function calculateEntryPoints(entryId, categoryId, rankings, rankingGroups) {
-    // Get all rankings for this entry from all judges
-    let entryRankings = [];
-    
-    // Check if entry belongs to a custom ranking group
-    let groupId = null;
-    for (const group of rankingGroups) {
-      let categoryIds;
-      try {
-        categoryIds = Array.isArray(group.bjcp_category_ids) 
-          ? group.bjcp_category_ids 
-          : JSON.parse(group.bjcp_category_ids);
-      } catch (e) {
-        console.warn('Failed to parse bjcp_category_ids for group:', group.id);
-        continue;
-      }
-      
-      if (categoryIds.includes(categoryId)) {
-        groupId = group.id;
-        break;
-      }
-    }
-    
-    if (groupId) {
-      // For custom ranking groups
-      entryRankings = rankings.filter(r => 
-        r.entry_id === entryId && r.ranking_group_id === groupId
-      );
-    } else {
-      // For individual categories
-      entryRankings = rankings.filter(r => 
-        r.entry_id === entryId && r.bjcp_category_id === categoryId
-      );
-    }
-
-    // Calculate total points from all judges
-    const totalPoints = entryRankings.reduce((sum, ranking) => {
-      return sum + getPointsForRanking(ranking.rank_position);
-    }, 0);
-
-    return {
-      totalPoints,
-      judgeCount: entryRankings.length,
-      rankings: entryRankings
-    };
-  }
+  // Ranking-points helpers now live in $lib/utils/scoring (calculateEntryPoints).
 
   // Load competitions with published results
   async function loadPublishedCompetitions() {

--- a/src/routes/officers/manage-competitions/judging-dashboard/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/judging-dashboard/[id]/+page.svelte
@@ -5,6 +5,14 @@
   import { page } from '$app/stores';
   import { userProfile } from '$lib/stores/userProfile';
   import { supabase } from '$lib/supabaseClient';
+  import {
+    getPointsForRanking,
+    compileEntryPoints,
+    hasMultipleJudges,
+    getUniqueEntriesFromRankings,
+    computeEntryScoreStats,
+    rankEntries
+  } from '$lib/utils/scoring';
   import Hero from '$lib/components/ui/Hero.svelte';
   import Container from '$lib/components/ui/Container.svelte';
   import LoadingSpinner from '$lib/components/ui/LoadingSpinner.svelte';
@@ -210,19 +218,9 @@
     };
   }
 
+  // Thin wrapper over the pure helper, bound to this page's judgingSessions.
   function getEntryScores(entryId) {
-    const entryScores = judgingSessions.filter(s => s.entry_id === entryId && s.total_score > 0);
-    if (entryScores.length === 0) return { count: 0, average: 0, scores: [] };
-
-    const scores = entryScores.map(s => s.total_score);
-    const average = Math.round(scores.reduce((sum, score) => sum + score, 0) / scores.length * 10) / 10;
-
-    return {
-      count: entryScores.length,
-      average,
-      scores,
-      sessions: entryScores
-    };
+    return computeEntryScoreStats(judgingSessions, entryId);
   }
 
   function getCategoryRankings(categoryId) {
@@ -247,23 +245,10 @@
     return entries.filter(entry => categoryIds.includes(entry.bjcp_category_id)).length;
   }
 
-  function hasMultipleJudges(rankings) {
-    const judgeIds = new Set(rankings.map(r => r.judge_id));
-    return judgeIds.size > 1;
-  }
-
+  // hasMultipleJudges / getUniqueEntriesFromRankings are imported from
+  // $lib/utils/scoring. This wrapper binds the pure compiler to page rankings.
   function getEntryPointsSummary(entryId, categoryId, groupId = null) {
-    return compileMultiJudgeRankings(entryId, categoryId, groupId);
-  }
-
-  function getUniqueEntriesFromRankings(rankings) {
-    const entryMap = new Map();
-    rankings.forEach(ranking => {
-      if (ranking.entry_id && !entryMap.has(ranking.entry_id)) {
-        entryMap.set(ranking.entry_id, ranking.entry);
-      }
-    });
-    return Array.from(entryMap.values());
+    return compileEntryPoints(rankings, entryId, { categoryId, groupId });
   }
 
   async function finalizeResults() {
@@ -284,43 +269,7 @@
     }
   }
 
-  function getPointsForRanking(rankPosition) {
-    // Point system: 1st=3pts, 2nd=2pts, 3rd=1pt, others=0pts
-    switch (rankPosition) {
-      case 1: return 3;
-      case 2: return 2;
-      case 3: return 1;
-      default: return 0;
-    }
-  }
-
-  function compileMultiJudgeRankings(entryId, categoryId, groupId = null) {
-    // Get all rankings for this entry from all judges
-    let entryRankings = [];
-    
-    if (groupId) {
-      // For custom ranking groups
-      entryRankings = rankings.filter(r => 
-        r.entry_id === entryId && r.ranking_group_id === groupId
-      );
-    } else {
-      // For individual categories
-      entryRankings = rankings.filter(r => 
-        r.entry_id === entryId && r.bjcp_category_id === categoryId
-      );
-    }
-
-    // Calculate total points from all judges
-    const totalPoints = entryRankings.reduce((sum, ranking) => {
-      return sum + getPointsForRanking(ranking.rank_position);
-    }, 0);
-
-    return {
-      totalPoints,
-      judgeCount: entryRankings.length,
-      rankings: entryRankings
-    };
-  }
+  // getPointsForRanking / compileEntryPoints are imported from $lib/utils/scoring.
 
   async function processAndFinalizeResults() {
     // This function aggregates all judging data and creates final results using multi-judge point compilation
@@ -372,59 +321,37 @@
 
     // Process each group separately to determine rankings
     for (const [groupKey, groupEntries] of entriesByGroup) {
-      // Calculate points for each entry in this group
+      // Compile each entry's points, then rank the group: points desc, average
+      // score as tiebreaker, placements assigned by rankEntries.
       const entriesWithPoints = groupEntries.map(entry => {
-        const compilation = compileMultiJudgeRankings(
-          entry.id, 
-          entry.bjcp_category_id, 
-          entry.groupId
-        );
-        
+        const compilation = compileEntryPoints(rankings, entry.id, {
+          categoryId: entry.bjcp_category_id,
+          groupId: entry.groupId
+        });
         return {
           ...entry,
-          compilation
+          compilation,
+          totalPoints: compilation.totalPoints,
+          averageScore: entry.entryScores.average
         };
       });
 
-      // Sort by total points (highest first), then by average score as tiebreaker
-      entriesWithPoints.sort((a, b) => {
-        if (b.compilation.totalPoints !== a.compilation.totalPoints) {
-          return b.compilation.totalPoints - a.compilation.totalPoints;
-        }
-        // Tiebreaker: use average score
-        return b.entryScores.average - a.entryScores.average;
-      });
-
-      // Assign placements based on final ranking
-      entriesWithPoints.forEach((entry, index) => {
-        // Calculate final score (average of all judges)
-        const finalScore = entry.entryScores.average;
-        
+      for (const entry of rankEntries(entriesWithPoints)) {
         // Get any judge notes
         const allNotes = entry.entryScores.sessions
           .filter(s => s.judge_notes)
           .map(s => s.judge_notes)
           .join('\n\n---\n\n');
 
-        // Determine placement based on compiled ranking position
-        let placement = null;
-        if (entry.compilation.totalPoints > 0) {
-          const rankPosition = index + 1;
-          if (rankPosition === 1) placement = '1';
-          else if (rankPosition === 2) placement = '2';
-          else if (rankPosition === 3) placement = '3';
-          else if (rankPosition <= 5) placement = 'HM'; // Honorable mention for top 5
-        }
-
         finalResults.push({
           competition_id: competitionId,
           entry_id: entry.id,
-          score: Math.round(finalScore),
-          placement: placement,
+          score: Math.round(entry.entryScores.average),
+          placement: entry.placement,
           judge_notes: allNotes || null,
           updated_at: new Date().toISOString()
         });
-      });
+      }
     }
 
     // Upsert results into competition_results: previously 2 sequential

--- a/src/routes/officers/manage-competitions/results/[id]/+page.svelte
+++ b/src/routes/officers/manage-competitions/results/[id]/+page.svelte
@@ -5,6 +5,7 @@
   import { page } from '$app/stores';
   import { userProfile } from '$lib/stores/userProfile';
   import { supabase } from '$lib/supabaseClient';
+  import { calculateEntryPoints } from '$lib/utils/scoring';
   import Hero from "$lib/components/ui/Hero.svelte";
   import Container from "$lib/components/ui/Container.svelte";
   import LoadingSpinner from "$lib/components/ui/LoadingSpinner.svelte";
@@ -63,63 +64,7 @@
     return 'Hidden'; // Hidden for non-Comp Directors
   }
 
-  // Helper functions for ranking points calculation
-  function getPointsForRanking(rankPosition) {
-    // Point system: 1st=3pts, 2nd=2pts, 3rd=1pt, others=0pts
-    switch (rankPosition) {
-      case 1: return 3;
-      case 2: return 2;
-      case 3: return 1;
-      default: return 0;
-    }
-  }
-
-  function calculateEntryPoints(entryId, categoryId, rankings, rankingGroups) {
-    // Get all rankings for this entry from all judges
-    let entryRankings = [];
-    
-    // Check if entry belongs to a custom ranking group
-    let groupId = null;
-    for (const group of rankingGroups) {
-      let categoryIds;
-      try {
-        categoryIds = Array.isArray(group.bjcp_category_ids) 
-          ? group.bjcp_category_ids 
-          : JSON.parse(group.bjcp_category_ids);
-      } catch (e) {
-        console.warn('Failed to parse bjcp_category_ids for group:', group.id);
-        continue;
-      }
-      
-      if (categoryIds.includes(categoryId)) {
-        groupId = group.id;
-        break;
-      }
-    }
-    
-    if (groupId) {
-      // For custom ranking groups
-      entryRankings = rankings.filter(r => 
-        r.entry_id === entryId && r.ranking_group_id === groupId
-      );
-    } else {
-      // For individual categories
-      entryRankings = rankings.filter(r => 
-        r.entry_id === entryId && r.bjcp_category_id === categoryId
-      );
-    }
-
-    // Calculate total points from all judges
-    const totalPoints = entryRankings.reduce((sum, ranking) => {
-      return sum + getPointsForRanking(ranking.rank_position);
-    }, 0);
-
-    return {
-      totalPoints,
-      judgeCount: entryRankings.length,
-      rankings: entryRankings
-    };
-  }
+  // Ranking-points helpers now live in $lib/utils/scoring (calculateEntryPoints).
 
   onMount(() => {
     loadCompetitionAndEntries();


### PR DESCRIPTION
Follow-up to #80 (the deferred "extract points/ranking into pure functions" item from #143).

## Problem
The competition point table (1st=3, 2nd=2, 3rd=1) and multi-judge compilation were **copied across three files** — the judging dashboard and both results pages — and completely untested. Regressions in scoring shipped undetected.

## Change
New **`src/lib/utils/scoring.js`** — pure, Svelte/Supabase-free:
- `getPointsForRanking`, `compileEntryPoints`, `calculateEntryPoints`
- `findRankingGroupIdForCategory` / `parseCategoryIds` (handles jsonb-array or JSON-string `bjcp_category_ids`)
- `hasMultipleJudges`, `getUniqueEntriesFromRankings`, `computeEntryScoreStats`
- `placementForRank` + `rankEntries` — the finalize algorithm: sort by points desc, average-score tiebreak, assign 1/2/3/HM, and never place a zero-point entry

All three components now import from it; their local copies are deleted, and the dashboard's `processAndFinalizeResults` uses `compileEntryPoints` + `rankEntries`.

## Behaviour
Unchanged — the pure functions mirror the originals. One cosmetic difference: a malformed `bjcp_category_ids` is now silently skipped instead of logging a `console.warn` (the parse result — skip the group — is identical).

## Tests
**`src/lib/utils/scoring.test.js`** — 40 new tests: point table edges, category-vs-group compilation, group resolution incl. malformed JSON, score averaging/rounding, and the full `rankEntries` ordering + placement + no-mutation contract.

```
Test Files  3 passed (3)
     Tests  67 passed (67)
```
`npm run check` (0 errors) and `npm run build` pass.

## Related
Extends the vitest foundation from #143. The remaining #80 item — a Playwright login→submit→approve smoke — is tracked separately (needs a seeded test DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)