### PR TITLE
fix(calendar): responsive month grid on mobile (#146)

### DIFF
--- a/src/routes/calendar/+page.svelte
+++ b/src/routes/calendar/+page.svelte
@@ -387,11 +387,14 @@
   }
 
   .grid-scroll {
+    /* Safety net only — the grid is fluid and shouldn't overflow (#146). */
     overflow-x: auto;
   }
 
   .grid-inner {
-    min-width: 640px;
+    /* No fixed floor: the 7 columns shrink to fit the viewport instead of
+       forcing horizontal scroll on phones. */
+    min-width: 0;
   }
 
   .weekday-row,
@@ -611,6 +614,53 @@
     .calendar-toolbar {
       flex-direction: column;
       align-items: flex-start;
+    }
+
+    /* ===== Responsive month grid (#146) =====
+       The 7-column grid stays on screen; cells shrink and each event collapses
+       to a colored dot so nothing runs off horizontally. */
+    .weekday-row,
+    .days-grid {
+      gap: calc(var(--space-1) / 2);
+    }
+
+    .weekday-cell {
+      font-size: 0.625rem;
+      letter-spacing: 0;
+      padding: 0;
+    }
+
+    .day-cell {
+      min-height: 3.5rem;
+      padding: calc(var(--space-1) / 2);
+      gap: calc(var(--space-1) / 2);
+    }
+
+    .day-number {
+      font-size: var(--font-size-xs);
+    }
+
+    /* Events become a wrapped row of dots. The chip stays an <a> (still
+       tappable, still carries title/label text for assistive tech); the time
+       and title are just visually collapsed inside the dot. */
+    .day-events {
+      flex-direction: row;
+      flex-wrap: wrap;
+      gap: calc(var(--space-1) / 2);
+      margin-top: auto;
+    }
+
+    .day-event-chip {
+      width: 8px;
+      height: 8px;
+      min-width: 8px;
+      padding: 0;
+      gap: 0;
+      border-radius: var(--radius-full);
+    }
+
+    .chip-time {
+      display: none;
     }
   }
 </style>


### PR DESCRIPTION
Closes #146

## Problem
The calendar month view forced `.grid-inner { min-width: 640px }` with `overflow-x: auto`, so on a phone (~440px) the 7-column grid ran off-screen — the page scrolled sideways and event chips like "6:00 PM First…" were clipped.

## Fix (option 3 from the issue — responsive month grid)
- **Drop the 640px floor** (`min-width: 0`) so the 7 columns shrink to fit the viewport instead of forcing horizontal scroll. `overflow-x: auto` stays as a harmless safety net.
- **Under 640px:** tighten cell `min-height`/padding/gaps and shrink the weekday labels and day numbers.
- **Events collapse to colored dots** — navy for timed, gold for all-day — in a wrapped row at the bottom of the cell; the chip time is hidden. Each dot is still an `<a>` link carrying the event `title` (tooltip + assistive tech), and the **List view** remains the richer per-event mobile experience.
- **Desktop (>640px) is unchanged** — full chips with time + title.

## Verification
- `stylelint` clean, `npm run check` 0 errors, `npm run build` passes.
- CSS-only change. The calendar sits behind the auth gate and renders live Google Calendar data, so I didn't stand up an authed local session to screenshot — **worth a quick look on a phone** when reviewing. Expected: no horizontal scroll at 360–440px; days with events show 1+ dots; tapping a dot opens the event; the month/List toggle still works.

## Note
Dots are an intentional density indicator, not full tap targets — individual events are best opened from List view on mobile (the issue's recommended primary path). If you'd prefer a "+N more" count or defaulting to List view under a breakpoint, easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)